### PR TITLE
[OpenCL] Fixes core_rnn_test and core_rnn_cell_test

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
@@ -343,7 +343,7 @@ class RNNCellTest(test.TestCase):
       self.assertTrue("cpu:14159" in outputs.device.lower())
 
   def testDeviceWrapperDynamicExecutionNodesAreAllProperlyLocated(self):
-    if not test.is_gpu_available() or test_util.is_sycl_enabled():
+    if not test.is_gpu_available():
       # Can't perform this test w/o a GPU
       return
 

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
@@ -352,7 +352,7 @@ class RNNCellTest(test.TestCase):
           "root", initializer=init_ops.constant_initializer(0.5)):
         x = array_ops.zeros([1, 1, 3])
         cell = core_rnn_cell_impl.DeviceWrapper(
-            core_rnn_cell_impl.GRUCell(3), "/gpu:0")
+            core_rnn_cell_impl.GRUCell(3), test_util.gpu_device_name())
         with ops.device("/cpu:0"):
           outputs, _ = rnn.dynamic_rnn(
               cell=cell, inputs=x, dtype=dtypes.float32)
@@ -364,7 +364,8 @@ class RNNCellTest(test.TestCase):
         _ = sess.run(outputs, options=opts, run_metadata=run_metadata)
 
       step_stats = run_metadata.step_stats
-      ix = 0 if "gpu" in step_stats.dev_stats[0].device else 1
+      ix = 0 if (("gpu"  in step_stats.dev_stats[0].device) or
+                 ("sycl" in step_stats.dev_stats[0].device)) else 1
       gpu_stats = step_stats.dev_stats[ix].node_stats
       cpu_stats = step_stats.dev_stats[1 - ix].node_stats
       self.assertFalse([s for s in cpu_stats if "gru_cell" in s.node_name])

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
@@ -1013,10 +1013,6 @@ class LSTMTest(test.TestCase):
       self.assertAllEqual(np.hstack(state_static_v), np.hstack(state_dynamic_v))
 
   def _testDynamicEquivalentToStaticRNN(self, use_gpu, use_sequence_length):
-    # Currently not implemented for OpenCL
-    if test_util.is_sycl_enabled():
-      return
-
     time_steps = 8
     num_units = 3
     num_proj = 4

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
@@ -2205,8 +2205,7 @@ class TensorArrayOnCorrectDeviceTest(test.TestCase):
     return run_metadata
 
   def testRNNOnCPUCellOnGPU(self):
-    # Currently not implemented for OpenCL
-    if not test.is_gpu_available() or test_util.is_sycl_enabled():
+    if not test.is_gpu_available():
       return  # Test requires access to a GPU
 
     run_metadata = self._execute_rnn_on(
@@ -2251,8 +2250,7 @@ class TensorArrayOnCorrectDeviceTest(test.TestCase):
     _assert_in("TensorArray", cpu_stats, gpu_stats)
 
   def testInputOnGPUCellNotDeclared(self):
-    # Currently not implemented for OpenCL
-    if not test.is_gpu_available() or test_util.is_sycl_enabled():
+    if not test.is_gpu_available():
       return  # Test requires access to a GPU
 
     run_metadata = self._execute_rnn_on(

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
@@ -2231,8 +2231,7 @@ class TensorArrayOnCorrectDeviceTest(test.TestCase):
     _assert_in("TensorArrayScatter", cpu_stats, gpu_stats)
 
   def testRNNOnCPUCellOnCPU(self):
-    # Currently not implemented for OpenCL
-    if not test.is_gpu_available() or test_util.is_sycl_enabled():
+    if not test.is_gpu_available():
       return  # Test requires access to a GPU
 
     run_metadata = self._execute_rnn_on(

--- a/tensorflow/core/framework/types.cc
+++ b/tensorflow/core/framework/types.cc
@@ -39,6 +39,14 @@ const char* const DEVICE_CPU = "CPU";
 const char* const DEVICE_GPU = "GPU";
 const char* const DEVICE_SYCL = "SYCL";
 
+const std::string DeviceName<Eigen::ThreadPoolDevice>::value = DEVICE_CPU;
+#if GOOGLE_CUDA
+const std::string DeviceName<Eigen::GpuDevice>::value = DEVICE_GPU;
+#endif  // GOOGLE_CUDA
+#ifdef TENSORFLOW_USE_SYCL
+const std::string DeviceName<Eigen::SyclDevice>::value = DEVICE_SYCL;
+#endif  // TENSORFLOW_USE_SYCL
+
 string DataTypeString(DataType dtype) {
   if (IsRefType(dtype)) {
     DataType non_ref = static_cast<DataType>(dtype - kDataTypeRefOffset);

--- a/tensorflow/core/framework/types.h
+++ b/tensorflow/core/framework/types.h
@@ -72,6 +72,28 @@ TF_EXPORT extern const char* const DEVICE_CPU;   // "CPU"
 TF_EXPORT extern const char* const DEVICE_GPU;   // "GPU"
 TF_EXPORT extern const char* const DEVICE_SYCL;  // "SYCL"
 
+template <typename Device>
+struct DeviceName {};
+
+template <>
+struct DeviceName<Eigen::ThreadPoolDevice> {
+  static const std::string value;
+};
+
+#if GOOGLE_CUDA
+template <>
+struct DeviceName<Eigen::GpuDevice> {
+  static const std::string value;
+};
+#endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+template <>
+struct DeviceName<Eigen::SyclDevice> {
+  static const std::string value;
+};
+#endif  // TENSORFLOW_USE_SYCL
+
 typedef gtl::InlinedVector<MemoryType, 4> MemoryTypeVector;
 typedef gtl::ArraySlice<MemoryType> MemoryTypeSlice;
 

--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -35,14 +35,13 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
-class BiasOp;
-
-template <typename T>
-class BiasOp<CPUDevice, T> : public BinaryOp<T> {
+class BiasOp : public BinaryOp<T> {
  public:
-  typedef CPUDevice Device;
   explicit BiasOp(OpKernelConstruction* context) : BinaryOp<T>(context) {
     string data_format;
     if (context->GetAttr("data_format", &data_format).ok()) {
@@ -51,8 +50,8 @@ class BiasOp<CPUDevice, T> : public BinaryOp<T> {
     } else {
       data_format_ = FORMAT_NHWC;
     }
-    OP_REQUIRES(context, data_format_ == FORMAT_NHWC,
-                errors::InvalidArgument("CPU BiasOp only supports NHWC."));
+    OP_REQUIRES(context, data_format_ == FORMAT_NHWC, errors::InvalidArgument(
+      DeviceName<Device>::value + " BiasOp only supports NHWC."));
   }
 
   void Compute(OpKernelContext* context) override {
@@ -122,6 +121,19 @@ class BiasOp<CPUDevice, T> : public BinaryOp<T> {
 TF_CALL_NUMBER_TYPES(REGISTER_KERNEL);
 #undef REGISTER_KERNEL
 
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_KERNEL(type)                                          \
+  REGISTER_KERNEL_BUILDER(                                             \
+      Name("BiasAdd").Device(DEVICE_SYCL).TypeConstraint<type>("T"),   \
+      BiasOp<SYCLDevice, type>);                                       \
+  REGISTER_KERNEL_BUILDER(                                             \
+      Name("BiasAddV1").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      BiasOp<SYCLDevice, type>);
+
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_KERNEL);
+#undef REGISTER_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
+
 namespace {
 
 void GetBiasValueDims(const Tensor& value_tensor, TensorFormat data_format,
@@ -165,12 +177,8 @@ struct AccumulatorType<Eigen::half> {
 }  // namespace
 
 template <typename Device, typename T>
-class BiasGradOp;
-
-template <typename T>
-class BiasGradOp<CPUDevice, T> : public OpKernel {
+class BiasGradOp : public OpKernel {
  public:
-  typedef CPUDevice Device;
   explicit BiasGradOp(OpKernelConstruction* context) : OpKernel(context) {
     string data_format;
     if (context->GetAttr("data_format", &data_format).ok()) {
@@ -179,8 +187,8 @@ class BiasGradOp<CPUDevice, T> : public OpKernel {
     } else {
       data_format_ = FORMAT_NHWC;
     }
-    OP_REQUIRES(context, data_format_ == FORMAT_NHWC,
-                errors::InvalidArgument("CPU BiasGradOp only supports NHWC."));
+    OP_REQUIRES(context, data_format_ == FORMAT_NHWC, errors::InvalidArgument(
+      DeviceName<Device>::value + " BiasGradOp only supports NHWC."));
   }
 
   void Compute(OpKernelContext* context) override {
@@ -215,7 +223,7 @@ class BiasGradOp<CPUDevice, T> : public OpKernel {
 #else
       Eigen::array<int, 1> reduction_axis = {0};
 #endif
-      output->template flat<T>().device(context->eigen_device<CPUDevice>()) =
+      output->template flat<T>().device(context->eigen_device<Device>()) =
           output_backprop.flat<T>()
               .template cast<typename AccumulatorType<T>::type>()
               .reshape(two_dims)
@@ -236,6 +244,16 @@ class BiasGradOp<CPUDevice, T> : public OpKernel {
 
 TF_CALL_NUMBER_TYPES(REGISTER_KERNEL);
 #undef REGISTER_KERNEL
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_KERNEL(type)                                            \
+  REGISTER_KERNEL_BUILDER(                                               \
+      Name("BiasAddGrad").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      BiasGradOp<SYCLDevice, type>);
+
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_KERNEL);
+#undef REGISTER_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
 
 #if GOOGLE_CUDA
 template <typename T>

--- a/tensorflow/core/kernels/tensor_array.cc
+++ b/tensorflow/core/kernels/tensor_array.cc
@@ -24,6 +24,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 namespace tensor_array {
 
@@ -51,6 +54,13 @@ TF_CALL_complex128(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 
 #endif  // GOOGLE_CUDA
 
+#ifdef TENSORFLOW_USE_SYCL
+#define TENSOR_ARRAY_WRITE_OR_ADD_SYCL(T) \
+  TENSOR_ARRAY_WRITE_OR_ADD(SYCLDevice, T)
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(TENSOR_ARRAY_WRITE_OR_ADD_SYCL);
+#undef TENSOR_ARRAY_WRITE_OR_ADD_SYCL
+#endif  // TENSORFLOW_USE_SYCL
+
 #undef TENSOR_ARRAY_WRITE_OR_ADD
 
 #define TENSOR_ARRAY_SET_ZERO(Device, T)                                      \
@@ -74,6 +84,12 @@ TF_CALL_complex128(TENSOR_ARRAY_SET_ZERO_GPU);
 #undef TENSOR_ARRAY_SET_ZERO_GPU
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define TENSOR_ARRAY_SET_ZERO_SYCL(T) TENSOR_ARRAY_SET_ZERO(SYCLDevice, T)
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(TENSOR_ARRAY_SET_ZERO_SYCL);
+#undef TENSOR_ARRAY_SET_ZERO_SYCL
+#endif  // TENSORFLOW_USE_SYCL
 
 #undef TENSOR_ARRAY_SET_ZERO
 

--- a/tensorflow/core/kernels/tensor_array.h
+++ b/tensorflow/core/kernels/tensor_array.h
@@ -36,6 +36,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 namespace tensor_array {
 
@@ -67,6 +70,13 @@ TF_CALL_complex128(TENSOR_ARRAY_WRITE_OR_ADD_GPU);
 
 #endif  // GOOGLE_CUDA
 
+#ifdef TENSORFLOW_USE_SYCL
+#define TENSOR_ARRAY_WRITE_OR_ADD_SYCL(T) \
+  TENSOR_ARRAY_WRITE_OR_ADD(SYCLDevice, T)
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(TENSOR_ARRAY_WRITE_OR_ADD_SYCL);
+#undef TENSOR_ARRAY_WRITE_OR_ADD_SYCL
+#endif  // TENSORFLOW_USE_SYCL
+
 #undef TENSOR_ARRAY_WRITE_OR_ADD
 
 template <typename Device, typename T>
@@ -93,6 +103,12 @@ TF_CALL_complex128(TENSOR_ARRAY_SET_ZERO_GPU);
 #undef TENSOR_ARRAY_SET_ZERO_GPU
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define TENSOR_ARRAY_SET_ZERO_SYCL(T) TENSOR_ARRAY_SET_ZERO(SYCLDevice, T)
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(TENSOR_ARRAY_SET_ZERO_SYCL);
+#undef TENSOR_ARRAY_SET_ZERO_SYCL
+#endif  // TENSORFLOW_USE_SYCL
 
 #undef TENSOR_ARRAY_SET_ZERO
 


### PR DESCRIPTION
I made SYCL use the same implementation as the CPU for AddBias, not sure if this is a good idea though? The test passes but it only check if the Cell has been allocated on a sycl device so it is a bit easy.
I haven't changed anything for core_rnn_test yet but 2 functions seem to pass.