### PR TITLE
Register ops

### DIFF
--- a/tensorflow/contrib/framework/kernels/zero_initializer_op.cc
+++ b/tensorflow/contrib/framework/kernels/zero_initializer_op.cc
@@ -28,6 +28,9 @@ namespace tensorflow {
 
 using CPUDevice = Eigen::ThreadPoolDevice;
 using GPUDevice = Eigen::GpuDevice;
+#ifdef TENSORFLOW_USE_SYCL
+using SYCLDevice = Eigen::SyclDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class ZeroInitializerOp : public OpKernel {
@@ -82,6 +85,12 @@ TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPEC);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
 #endif // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(T) REGISTER_KERNELS(SYCL, T);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 
 #undef REGISTER_KERNELS
 

--- a/tensorflow/contrib/seq2seq/kernels/beam_search_ops.cc
+++ b/tensorflow/contrib/seq2seq/kernels/beam_search_ops.cc
@@ -39,6 +39,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class GatherTreeOp : public OpKernel {
@@ -170,5 +173,16 @@ DECLARE_GPU_SPEC(int32);
 REGISTER_GPU_KERNEL(int32);
 #undef REGISTER_GPU_KERNEL
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+// Use the CPU even though the user registered it on SYCL
+#define REGISTER_SYCL_KERNEL(T)                                      \
+  REGISTER_KERNEL_BUILDER(                                           \
+      Name("GatherTree").Device(DEVICE_SYCL).TypeConstraint<T>("T"), \
+      GatherTreeOp<CPUDevice, T>);
+
+REGISTER_SYCL_KERNEL(int32);
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/adjust_contrast_op.cc
+++ b/tensorflow/core/kernels/adjust_contrast_op.cc
@@ -31,6 +31,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 // AdjustContrastOp is deprecated as of GraphDef version >= 2
 
@@ -135,6 +138,16 @@ REGISTER_GPU_KERNEL(double);
 
 #endif  // GOOGLE_CUDA
 
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNEL(T)                                          \
+  REGISTER_KERNEL_BUILDER(                                               \
+      Name("AdjustContrast").Device(DEVICE_SYCL).TypeConstraint<T>("T"), \
+      AdjustContrastOp<SYCLDevice, T>);
+REGISTER_SYCL_KERNEL(float);
+REGISTER_SYCL_KERNEL(double);
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
+
 class AdjustContrastOpV2Base : public OpKernel {
  protected:
   explicit AdjustContrastOpV2Base(OpKernelConstruction* context)
@@ -187,10 +200,7 @@ class AdjustContrastOpV2Base : public OpKernel {
 };
 
 template <typename Device>
-class AdjustContrastOpv2;
-
-template <>
-class AdjustContrastOpv2<CPUDevice> : public AdjustContrastOpV2Base {
+class AdjustContrastOpv2 : public AdjustContrastOpV2Base {
  public:
   explicit AdjustContrastOpv2(OpKernelConstruction* context)
       : AdjustContrastOpV2Base(context) {}
@@ -409,5 +419,10 @@ class AdjustContrastOpv2<GPUDevice> : public AdjustContrastOpV2Base {
 REGISTER_KERNEL_BUILDER(Name("AdjustContrastv2").Device(DEVICE_GPU),
                         AdjustContrastOpv2<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("AdjustContrastv2").Device(DEVICE_SYCL),
+                        AdjustContrastOpv2<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/adjust_hue_op.cc
+++ b/tensorflow/core/kernels/adjust_hue_op.cc
@@ -36,6 +36,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 class AdjustHueOpBase : public OpKernel {
  protected:
@@ -276,6 +279,11 @@ class AdjustHueOp<GPUDevice> : public AdjustHueOpBase {
 
 REGISTER_KERNEL_BUILDER(Name("AdjustHue").Device(DEVICE_GPU),
                         AdjustHueOp<GPUDevice>);
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("AdjustHue").Device(DEVICE_SYCL),
+                        AdjustHueOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 #endif
 

--- a/tensorflow/core/kernels/colorspace_op.cc
+++ b/tensorflow/core/kernels/colorspace_op.cc
@@ -35,6 +35,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class RGBToHSVOp : public OpKernel {
@@ -145,5 +148,18 @@ TF_CALL_double(DECLARE_GPU);
 TF_CALL_float(REGISTER_GPU);
 TF_CALL_double(REGISTER_GPU);
 #endif
+
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL(T)                                       \
+  REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_SYCL) \
+                              .TypeConstraint<T>("T"),         \
+                          RGBToHSVOp<SYCLDevice, T>);          \
+  REGISTER_KERNEL_BUILDER(Name("HSVToRGB").Device(DEVICE_SYCL) \
+                              .TypeConstraint<T>("T"),         \
+                          HSVToRGBOp<SYCLDevice, T>);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL);
+#undef REGISTER_SYCL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cross_op.cc
+++ b/tensorflow/core/kernels/cross_op.cc
@@ -35,6 +35,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename Type>
 class CrossOp : public OpKernel {
@@ -108,5 +111,14 @@ TF_CALL_REAL_NUMBER_TYPES(DECLARE_GPU_KERNEL);
 TF_CALL_REAL_NUMBER_TYPES(REGISTER_GPU_KERNEL);
 #undef REGISTER_GPU_KERNEL
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNEL(type)                                 \
+  REGISTER_KERNEL_BUILDER(                                         \
+      Name("Cross").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      CrossOp<SYCLDevice, type>);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNEL);
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_logical_and.cc
+++ b/tensorflow/core/kernels/cwise_op_logical_and.cc
@@ -22,4 +22,8 @@ REGISTER_KERNEL_BUILDER(Name("LogicalAnd").Device(DEVICE_CPU),
 REGISTER_KERNEL_BUILDER(Name("LogicalAnd").Device(DEVICE_GPU),
                         BinaryOp<GPUDevice, functor::logical_and>);
 #endif
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("LogicalAnd").Device(DEVICE_SYCL),
+                        BinaryOp<SYCLDevice, functor::logical_and>);
+#endif  // TENSORFLOW_USE_SYCL
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_logical_not.cc
+++ b/tensorflow/core/kernels/cwise_op_logical_not.cc
@@ -22,4 +22,8 @@ REGISTER_KERNEL_BUILDER(Name("LogicalNot").Device(DEVICE_CPU),
 REGISTER_KERNEL_BUILDER(Name("LogicalNot").Device(DEVICE_GPU),
                         UnaryOp<GPUDevice, functor::logical_not>);
 #endif
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("LogicalNot").Device(DEVICE_SYCL),
+                        UnaryOp<SYCLDevice, functor::logical_not>);
+#endif  // TENSORFLOW_USE_SYCL
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_logical_or.cc
+++ b/tensorflow/core/kernels/cwise_op_logical_or.cc
@@ -22,4 +22,8 @@ REGISTER_KERNEL_BUILDER(Name("LogicalOr").Device(DEVICE_CPU),
 REGISTER_KERNEL_BUILDER(Name("LogicalOr").Device(DEVICE_GPU),
                         BinaryOp<GPUDevice, functor::logical_or>);
 #endif
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("LogicalOr").Device(DEVICE_SYCL),
+                        BinaryOp<SYCLDevice, functor::logical_or>);
+#endif  // TENSORFLOW_USE_SYCL
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -38,6 +38,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class DepthToSpaceOp : public OpKernel {
@@ -96,11 +99,12 @@ class DepthToSpaceOp : public OpKernel {
   int block_size_;
 };
 
-// Partial specialization of DepthToSpaceOpFunctor for a CPUDevice.
+// Partial specialization of DepthToSpaceOpFunctor for a CPUDevice
+// and SYCLDevice.
 namespace functor {
-template <typename T>
-struct DepthToSpaceOpFunctor<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
+template <typename Device, typename T>
+struct DepthToSpaceOpFunctorNonCuda {
+  void operator()(const Device& d, typename TTypes<T, 4>::ConstTensor input,
                   int block_size, typename TTypes<T, 4>::Tensor output) {
     const int batch_size = output.dimension(0);
     const int output_height = output.dimension(1);
@@ -125,6 +129,16 @@ struct DepthToSpaceOpFunctor<CPUDevice, T> {
     }
   }
 };
+
+template <typename T>
+struct DepthToSpaceOpFunctor<CPUDevice, T> :
+    DepthToSpaceOpFunctorNonCuda<CPUDevice, T> {};
+
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct DepthToSpaceOpFunctor<SYCLDevice, T> :
+    DepthToSpaceOpFunctorNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
 }  // namespace functor
 
 #define REGISTER(type)                                                   \
@@ -140,5 +154,11 @@ REGISTER_KERNEL_BUILDER(
     Name("DepthToSpace").Device(DEVICE_GPU).TypeConstraint<float>("T"),
     DepthToSpaceOp<GPUDevice, float>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("DepthToSpace").Device(DEVICE_SYCL).TypeConstraint<float>("T"),
+    DepthToSpaceOp<SYCLDevice, float>);
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/fake_quant_ops.cc
+++ b/tensorflow/core/kernels/fake_quant_ops.cc
@@ -33,6 +33,9 @@ using tensorflow::DEVICE_CPU;
 #if GOOGLE_CUDA
 using tensorflow::DEVICE_GPU;
 #endif
+#ifdef TENSORFLOW_USE_SYCL
+using tensorflow::DEVICE_SYCL;
+#endif  // TENSORFLOW_USE_SYCL
 using tensorflow::DT_BOOL;
 using tensorflow::OpKernel;
 using tensorflow::OpKernelConstruction;
@@ -155,6 +158,17 @@ REGISTER_KERNEL_BUILDER(
     Name("FakeQuantWithMinMaxArgsGradient").Device(DEVICE_GPU),
     FakeQuantWithMinMaxArgsGradientOp<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxArgs")
+                            .Device(DEVICE_SYCL),
+                        FakeQuantWithMinMaxArgsOp<SYCLDevice>);
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxArgsGradient")
+                            .Device(DEVICE_SYCL),
+                        FakeQuantWithMinMaxArgsGradientOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 // -----------------------------------------------------------------------------
 // Implementation of FakeQuantWithMinMaxVarsOp, see its documentation in
@@ -311,6 +325,19 @@ REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsGradient")
                             .HostMemory("max"),
                         FakeQuantWithMinMaxVarsGradientOp<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVars")
+                            .Device(DEVICE_SYCL)
+                            .HostMemory("min")
+                            .HostMemory("max"),
+                        FakeQuantWithMinMaxVarsOp<SYCLDevice>);
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsGradient")
+                            .Device(DEVICE_SYCL)
+                            .HostMemory("min")
+                            .HostMemory("max"),
+                        FakeQuantWithMinMaxVarsGradientOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 // -----------------------------------------------------------------------------
 // Implementation of FakeQuantWithMinMaxVarsPerChannelOp, see its documentation
@@ -607,5 +634,18 @@ REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsPerChannelGradient")
                             .HostMemory("max"),
                         FakeQuantWithMinMaxVarsPerChannelGradientOp<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsPerChannel")
+                            .Device(DEVICE_SYCL)
+                            .HostMemory("min")
+                            .HostMemory("max"),
+                        FakeQuantWithMinMaxVarsPerChannelOp<SYCLDevice>);
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsPerChannelGradient")
+                            .Device(DEVICE_SYCL)
+                            .HostMemory("min")
+                            .HostMemory("max"),
+                        FakeQuantWithMinMaxVarsPerChannelGradientOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/l2loss_op.cc
+++ b/tensorflow/core/kernels/l2loss_op.cc
@@ -28,6 +28,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class L2LossOp : public OpKernel {
@@ -85,5 +88,15 @@ REGISTER_GPU_KERNEL(Eigen::half);
 #undef REGISTER_GPU_KERNEL
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNEL(T)                                  \
+  REGISTER_KERNEL_BUILDER(                                       \
+      Name("L2Loss").Device(DEVICE_SYCL).TypeConstraint<T>("T"), \
+      L2LossOp<SYCLDevice, T>);
+
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNEL);
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/reduction_ops_all.cc
+++ b/tensorflow/core/kernels/reduction_ops_all.cc
@@ -33,4 +33,13 @@ REGISTER_KERNEL_BUILDER(
     ReductionOp<GPUDevice, bool, Eigen::internal::AndReducer>);
 #endif
 
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("All")
+        .TypeConstraint<int32>("Tidx")
+        .Device(DEVICE_SYCL)
+        .HostMemory("reduction_indices"),
+    ReductionOp<SYCLDevice, bool, Eigen::internal::AndReducer>);
+#endif  // TENSORFLOW_USE_SYCL
+
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/reduction_ops_any.cc
+++ b/tensorflow/core/kernels/reduction_ops_any.cc
@@ -33,4 +33,13 @@ REGISTER_KERNEL_BUILDER(
     ReductionOp<GPUDevice, bool, Eigen::internal::OrReducer>);
 #endif
 
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("Any")
+        .TypeConstraint<int32>("Tidx")
+        .Device(DEVICE_SYCL)
+        .HostMemory("reduction_indices"),
+    ReductionOp<SYCLDevice, bool, Eigen::internal::OrReducer>);
+#endif  // TENSORFLOW_USE_SYCL
+
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/softplus_op.cc
+++ b/tensorflow/core/kernels/softplus_op.cc
@@ -30,6 +30,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+using SYCLDevice = Eigen::SyclDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class SoftplusOp : public UnaryElementWiseOp<T, SoftplusOp<Device, T>> {
@@ -125,5 +128,17 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(type)                                       \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("Softplus").Device(DEVICE_SYCL).TypeConstraint<type>("T"),     \
+      SoftplusOp<SYCLDevice, type>);                                      \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("SoftplusGrad").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      SoftplusGradOp<SYCLDevice, type>);
+
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/softsign_op.cc
+++ b/tensorflow/core/kernels/softsign_op.cc
@@ -30,6 +30,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class SoftsignOp : public UnaryElementWiseOp<T, SoftsignOp<Device, T>> {
@@ -126,5 +129,18 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(type)                                       \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("Softsign").Device(DEVICE_SYCL).TypeConstraint<type>("T"),     \
+      SoftsignOp<SYCLDevice, type>);                                      \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("SoftsignGrad").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      SoftsignGradOp<SYCLDevice, type>);
+
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -62,9 +62,9 @@ struct ApplyGradientDescentSYCL {
 };
 #endif
 
-template <typename T>
-struct ApplyAdadelta<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+template <typename Device, typename T>
+struct ApplyAdadeltaNonCuda {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
                   typename TTypes<T>::Flat accum,
                   typename TTypes<T>::Flat accum_update,
                   typename TTypes<T>::ConstScalar lr,
@@ -80,6 +80,13 @@ struct ApplyAdadelta<CPUDevice, T> {
     var.device(d) -= update * lr();
   }
 };
+
+template <typename T>
+struct ApplyAdadelta<CPUDevice, T> : ApplyAdadeltaNonCuda<CPUDevice, T> {};
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct ApplyAdadelta<SYCLDevice, T> : ApplyAdadeltaNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename T>
 struct ApplyProximalGradientDescent<CPUDevice, T> {
@@ -145,9 +152,9 @@ struct ApplyAdagradDA<CPUDevice, T> {
   }
 };
 
-template <typename T>
-struct ApplyAdagrad<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+template <typename Device, typename T>
+struct ApplyAdagradNonCuda {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
                   typename TTypes<T>::Flat accum,
                   typename TTypes<T>::ConstScalar lr,
                   typename TTypes<T>::ConstFlat grad) {
@@ -155,6 +162,13 @@ struct ApplyAdagrad<CPUDevice, T> {
     var.device(d) -= grad * lr() * accum.rsqrt();
   }
 };
+
+template <typename T>
+struct ApplyAdagrad<CPUDevice, T> : ApplyAdagradNonCuda<CPUDevice, T> {};
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct ApplyAdagrad<SYCLDevice, T> : ApplyAdagradNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename T>
 struct ApplyProximalAdagrad<CPUDevice, T> {
@@ -184,9 +198,9 @@ struct ApplyProximalAdagrad<CPUDevice, T> {
   }
 };
 
-template <typename T>
-struct ApplyFtrl<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+template <typename Device, typename T>
+struct ApplyFtrlNonCuda {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
                   typename TTypes<T>::Flat accum,
                   typename TTypes<T>::Flat linear,
                   typename TTypes<T>::ConstFlat grad,
@@ -223,8 +237,15 @@ struct ApplyFtrl<CPUDevice, T> {
 };
 
 template <typename T>
-struct ApplyMomentum<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+struct ApplyFtrl<CPUDevice, T> : ApplyFtrlNonCuda<CPUDevice, T> {};
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct ApplyFtrl<SYCLDevice, T> : ApplyFtrlNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
+
+template <typename Device, typename T>
+struct ApplyMomentumNonCuda {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
                   typename TTypes<T>::Flat accum,
                   typename TTypes<T>::ConstScalar lr,
                   typename TTypes<T>::ConstFlat grad,
@@ -237,6 +258,13 @@ struct ApplyMomentum<CPUDevice, T> {
     }
   }
 };
+
+template <typename T>
+struct ApplyMomentum<CPUDevice, T> : ApplyMomentumNonCuda<CPUDevice, T> {};
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct ApplyMomentum<SYCLDevice, T> : ApplyMomentumNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 struct ApplyAdamNonCuda {
@@ -286,9 +314,9 @@ struct ApplyAdamSYCL {
 template <typename T>
 struct ApplyAdam<CPUDevice, T> : ApplyAdamNonCuda<CPUDevice, T> {};
 
-template <typename T>
-struct ApplyRMSProp<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+template <typename Device, typename T>
+struct ApplyRMSPropNonCuda {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
                   typename TTypes<T>::Flat ms, typename TTypes<T>::Flat mom,
                   typename TTypes<T>::ConstScalar lr,
                   typename TTypes<T>::ConstScalar rho,
@@ -303,8 +331,15 @@ struct ApplyRMSProp<CPUDevice, T> {
 };
 
 template <typename T>
-struct ApplyCenteredRMSProp<CPUDevice, T> {
-  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+struct ApplyRMSProp<CPUDevice, T> : ApplyRMSPropNonCuda<CPUDevice, T> {};
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct ApplyRMSProp<SYCLDevice, T> : ApplyRMSPropNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
+
+template <typename Device, typename T>
+struct ApplyCenteredRMSPropNonCuda {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
                   typename TTypes<T>::Flat mg, typename TTypes<T>::Flat ms,
                   typename TTypes<T>::Flat mom,
                   typename TTypes<T>::ConstScalar lr,
@@ -319,6 +354,15 @@ struct ApplyCenteredRMSProp<CPUDevice, T> {
     var.device(d) -= mom;
   }
 };
+
+template <typename T>
+struct ApplyCenteredRMSProp<CPUDevice, T> :
+  ApplyCenteredRMSPropNonCuda<CPUDevice, T> {};
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct ApplyCenteredRMSProp<SYCLDevice, T> :
+  ApplyCenteredRMSPropNonCuda<SYCLDevice, T> {};
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace functor
 
@@ -600,6 +644,12 @@ REGISTER_KERNELS(GPU, Eigen::half);
 REGISTER_KERNELS(GPU, float);
 REGISTER_KERNELS(GPU, double);
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(T) REGISTER_KERNELS(SYCL, T);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 #undef REGISTER_CPU_KERNELS
 #undef REGISTER_KERNELS
 
@@ -1058,6 +1108,12 @@ REGISTER_KERNELS(GPU, Eigen::half);
 REGISTER_KERNELS(GPU, float);
 REGISTER_KERNELS(GPU, double);
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(T) REGISTER_KERNELS(SYCL, T);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 #undef REGISTER_CPU_KERNELS
 #undef REGISTER_KERNELS
 
@@ -2195,6 +2251,12 @@ REGISTER_KERNELS(GPU, Eigen::half);
 REGISTER_KERNELS(GPU, float);
 REGISTER_KERNELS(GPU, double);
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(T) REGISTER_KERNELS(SYCL, T);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 #undef REGISTER_CPU_KERNELS
 #undef REGISTER_KERNELS
 
@@ -2817,6 +2879,12 @@ REGISTER_KERNELS(GPU, Eigen::half);
 REGISTER_KERNELS(GPU, float);
 REGISTER_KERNELS(GPU, double);
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(T) REGISTER_KERNELS(SYCL, T);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 #undef REGISTER_CPU_KERNELS
 #undef REGISTER_KERNELS
 


### PR DESCRIPTION
Here's a bunch of ops that missed a SYCL registration.
For now it makes more tests fail but this is expected while there is still this pointer issue.
The new fails with these changes are:
```
//tensorflow/contrib/grid_rnn:grid_rnn_test
//tensorflow/python:control_flow_ops_test
//tensorflow/python:image_grad_test
//tensorflow/python:image_ops_test
//tensorflow/python/kernel_tests:batchtospace_op_test
//tensorflow/python/kernel_tests:concat_op_test
//tensorflow/python/kernel_tests:gather_op_test
//tensorflow/python/kernel_tests:lrn_op_test
//tensorflow/python/kernel_tests:matmul_op_test
//tensorflow/python/kernel_tests:morphological_ops_test
//tensorflow/python/kernel_tests:multinomial_op_test
//tensorflow/python/kernel_tests:numerics_test
//tensorflow/python/kernel_tests:parameterized_truncate
//tensorflow/python/kernel_tests:sparse_tensor_dense_ma
//tensorflow/python/kernel_tests:sparse_tensor_dense_ma
//tensorflow/python:quantize_training_test
//tensorflow/python:rmsprop_test
```