### PR TITLE
Adds SYCL support for memory stats

### DIFF
--- a/tensorflow/contrib/memory_stats/kernels/memory_stats_ops.cc
+++ b/tensorflow/contrib/memory_stats/kernels/memory_stats_ops.cc
@@ -57,6 +57,11 @@ REGISTER_KERNEL_BUILDER(Name("BytesLimit").Device(DEVICE_CPU), BytesLimitOp);
 REGISTER_KERNEL_BUILDER(Name("BytesLimit").Device(DEVICE_GPU).HostMemory("out"),
                         BytesLimitOp);
 
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("BytesLimit").Device(DEVICE_SYCL).HostMemory("out"),
+                        BytesLimitOp);
+#endif // TENSORFLOW_USE_SYCL
+
 // Op that measures the peak memory in bytes.
 class MaxBytesInUseOp : public MemoryStatsOp {
  public:
@@ -75,5 +80,11 @@ class MaxBytesInUseOp : public MemoryStatsOp {
 REGISTER_KERNEL_BUILDER(
     Name("MaxBytesInUse").Device(DEVICE_GPU).HostMemory("out"),
     MaxBytesInUseOp);
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("MaxBytesInUse").Device(DEVICE_SYCL).HostMemory("out"),
+    MaxBytesInUseOp);
+#endif // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -19,6 +19,14 @@ limitations under the License.
 
 namespace tensorflow {
 
+SYCLAllocator::SYCLAllocator(Eigen::QueueInterface *queue)
+    : sycl_device_(new Eigen::SyclDevice(queue)) {
+  cl::sycl::queue& sycl_queue = sycl_device_->sycl_queue();
+  const cl::sycl::device& device = sycl_queue.get_device();
+  stats_.bytes_limit =
+      device.get_info<cl::sycl::info::device::max_mem_alloc_size>();
+}
+
 SYCLAllocator::~SYCLAllocator() {
   if(sycl_device_) {
     delete sycl_device_;
@@ -30,16 +38,37 @@ string SYCLAllocator::Name() { return "device:SYCL"; }
 void *SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
   assert(sycl_device_);
   if (num_bytes == 0) {
-    return sycl_device_->allocate(1);
+    // Cannot allocate no bytes in SYCL, so instead allocate a single byte
+    num_bytes = 1;
   }
   auto p = sycl_device_->allocate(num_bytes);
+  const auto& allocated_buffer = sycl_device_->get_sycl_buffer(p);
+  const std::size_t bytes_allocated = allocated_buffer.get_range().size();
+
+  mutex_lock lock(mu_);
+  ++stats_.num_allocs;
+  stats_.bytes_in_use += bytes_allocated;
+  stats_.max_bytes_in_use =
+      std::max<int64>(stats_.max_bytes_in_use, stats_.bytes_in_use);
+  stats_.max_alloc_size =
+      std::max<int64>(stats_.max_alloc_size, bytes_allocated);
+
   return p;
 }
 
 void SYCLAllocator::DeallocateRaw(void *ptr) {
+  const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
+  const std::size_t dealloc_size = buffer_to_delete.get_range().size();
+  mutex_lock lock(mu_);
+  stats_.bytes_in_use -= dealloc_size;
   if (sycl_device_) {
     sycl_device_->deallocate(ptr);
   }
+}
+
+void SYCLAllocator::GetStats(AllocatorStats* stats) {
+  mutex_lock lock(mu_);
+  *stats = stats_;
 }
 
 }  // namespace tensorflow


### PR DESCRIPTION
Fixes the test fail:
//tensorflow/contrib/memory_stats:memory_stats_ops_test