### PR TITLE
Fixes CUDA specific sparse_tensor_dense_matmul test being run on SYCL devices

### DIFF
--- a/tensorflow/python/kernel_tests/sparse_tensor_dense_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_tensor_dense_matmul_op_test.py
@@ -163,8 +163,9 @@ class SparseTensorDenseMatMulTest(test.TestCase):
             sparse_t, dense_t, adjoint_a=True).eval()
 
   def testInvalidIndicesForSparseTensorDenseMatmulOnGPU(self):
-    # Note: use_gpu=False because nice errors are only returned from CPU kerne
-    if not test.is_gpu_available():
+    # Only run this test when using CUDA GPUs. CPU and SYCL devices do not have
+    # the same behaviour
+    if not test.is_gpu_available(cuda_only=True):
       return
     with self.test_session(use_gpu=True):
       indices = np.array([[1, 10]]).astype(np.int64)

--- a/tensorflow/python/kernel_tests/sparse_tensor_dense_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_tensor_dense_matmul_op_test.py
@@ -132,8 +132,10 @@ class SparseTensorDenseMatMulTest(test.TestCase):
       sparse_ops.sparse_tensor_dense_matmul(x_st_shape_inconsistent, y)
 
   def testInvalidIndicesForSparseTensorDenseMatmul(self):
-    # Note: use_gpu=False because nice errors are only returned from CPU kernel.
-    with self.test_session(use_gpu=False):
+    # Note: Don't want to test this on CUDA GPUs, as that kernel does not
+    # return these nice errors.
+    use_gpu = not test.is_gpu_available(cuda_only=True)
+    with self.test_session(use_gpu=use_gpu):
       indices = np.matrix([[1, 10]]).astype(np.int64)
       values = np.array([10]).astype(np.float32)
       shape = [3, 2]

--- a/tensorflow/python/kernel_tests/sparse_tensor_dense_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_tensor_dense_matmul_op_test.py
@@ -132,10 +132,8 @@ class SparseTensorDenseMatMulTest(test.TestCase):
       sparse_ops.sparse_tensor_dense_matmul(x_st_shape_inconsistent, y)
 
   def testInvalidIndicesForSparseTensorDenseMatmul(self):
-    # Note: Don't want to test this on CUDA GPUs, as that kernel does not
-    # return these nice errors.
-    use_gpu = not test.is_gpu_available(cuda_only=True)
-    with self.test_session(use_gpu=use_gpu):
+    # Note: use_gpu=False because nice errors are only returned from CPU kernel.
+    with self.test_session(use_gpu=False):
       indices = np.matrix([[1, 10]]).astype(np.int64)
       values = np.array([10]).astype(np.float32)
       shape = [3, 2]


### PR DESCRIPTION
Ensures that the CUDA specific test is only run on CUDA devices, and allows the general test to use SYCL devices if present.