### PR TITLE
[OpenCL] Registers SparseSoftmaxCrossEntropyWithLogits

### DIFF
--- a/tensorflow/core/kernels/sparse_xent_op.cc
+++ b/tensorflow/core/kernels/sparse_xent_op.cc
@@ -121,7 +121,7 @@ struct SparseXentFunctor<SYCLDevice, T, Index> {
                   typename TTypes<T>::Vec scratch, typename TTypes<T>::Vec loss,
                   typename TTypes<T>::Matrix backprop) {
     SparseXentEigenImpl<SYCLDevice, T, Index>::Compute(d, logits, labels,
-                                                      scratch, loss, backprop);
+                                                       scratch, loss, backprop);
   }
 };
 #endif  //TENSORFLOW_USE_SYCL


### PR DESCRIPTION
The test tensorflow/python/ops/losses:util_test fails unless "pointer to struct" problem is fixed.