### PR TITLE
[OpenCL] Fixes GatherOP on SYCL devices

### DIFF
--- a/tensorflow/core/kernels/gather_functor.cc
+++ b/tensorflow/core/kernels/gather_functor.cc
@@ -67,7 +67,7 @@ struct GatherFunctor<SYCLDevice, T, Index> {
       // was a security risk since it could have changed in between.
       const Index index = internal::SubtleMustCopy(indices(i));
       if (!FastBoundsCheck(index, limit)) return i;
-      out.template chip<0>(i) = params.template chip<0>(index);
+      out.template chip<0>(i).device(d) = params.template chip<0>(index);
     }
     return -1;
   }

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -53,7 +53,7 @@ struct UnsortedSegmentSumFunctor: public UnsortedSegmentBaseFunctor<Device, T, I
                   const Index output_rows, const TensorShape& segment_ids_shape,
                   typename TTypes<Index>::ConstFlat segment_ids,
                   const Index data_size, const T* data,
-                  typename TTypes<T, 2>::Tensor output);
+                  typename TTypes<T, 2>::Tensor output) override;
 };
 
 // Functor for UnsortedSegmentMaxOp.


### PR DESCRIPTION
Ensures that both GatherFunctor and UnsortedSegmentSumFunctor are actually computed on the device, not CPU.
Unifies CPU and SYCL versions of UnsortedSegmentSumFunctor.
Fixes #43.