### PR TITLE
[OpenCL] Provides SYCL kernels for 3D pooling

### DIFF
--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -851,30 +851,6 @@ TF_CALL_float(REGISTER_GPU_KERNELS) TF_CALL_half(REGISTER_GPU_KERNELS)
 // convenient constructors.
 struct SYCL3DPoolParams {
   SYCL3DPoolParams(const int depth, const int batch, const int in_planes,
-                   const int in_rows, const int in_cols,
-                   const std::array<int64, 3>& out_shape,
-                   const std::array<int64, 3>& window,
-                   const std::array<int64, 3>& stride,
-                   const std::array<int64, 3>& padding)
-      : depth_(depth),
-        batch_(batch),
-        in_planes_(in_planes),
-        in_rows_(in_rows),
-        in_cols_(in_cols),
-        window_planes_(window[2]),
-        window_rows_(window[1]),
-        window_cols_(window[0]),
-        stride_planes_(stride[2]),
-        stride_rows_(stride[1]),
-        stride_cols_(stride[0]),
-        out_planes_(out_shape[2]),
-        out_rows_(out_shape[1]),
-        out_cols_(out_shape[0]),
-        pad_planes_(padding[2]),
-        pad_rows_(padding[1]),
-        pad_cols_(padding[0]) {}
-
-  SYCL3DPoolParams(const int depth, const int batch, const int in_planes,
                    const int in_rows, const int in_cols, const int out_planes,
                    const int out_rows, const int out_cols,
                    const std::array<int64, 3>& window,
@@ -897,6 +873,16 @@ struct SYCL3DPoolParams {
         pad_planes_(padding[2]),
         pad_rows_(padding[1]),
         pad_cols_(padding[0]) {}
+
+  SYCL3DPoolParams(const int depth, const int batch, const int in_planes,
+                   const int in_rows, const int in_cols,
+                   const std::array<int64, 3>& out_shape,
+                   const std::array<int64, 3>& window,
+                   const std::array<int64, 3>& stride,
+                   const std::array<int64, 3>& padding)
+      : SYCL3DPoolParams(depth, batch, in_planes, in_rows, in_cols,
+                         out_shape[2], out_shape[1], out_shape[0], window,
+                         stride, padding) {}
 
   SYCL3DPoolParams(const Pool3dParameters& params)
       : depth_(params.depth),

--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -37,6 +37,11 @@ limitations under the License.
 #include "tensorflow/core/kernels/cudnn_pooling_gpu.h"
 #include "tensorflow/core/kernels/pooling_ops_3d_gpu.h"
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#include "tensorflow/core/util/sycl_util.h"
+#endif  // TENSORFLOW_USE_SYCL
+
 namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
@@ -1041,19 +1046,6 @@ struct LaunchPoolingOp<SYCLDevice, T, MAX> {
     });
   }
 };
-
-// Need an atomic add for the MaxPool3DGrad kernel. For the device, this need a
-// pointer to global memory which isn't understood by the host. The host should
-// never be calling this method, but we provide the header so that the host
-// compiler can compile the MaxPool3DGrad functor.
-#ifdef __SYCL_DEVICE_ONLY__
-template <typename T>
-void SyclAtomicAdd(__attribute__((address_space(1))) T* address,
-                   const T increment);
-#else
-template <typename T>
-void SyclAtomicAdd(T* address, const T increment);
-#endif  // __SYCL_DEVICE_ONLY__
 // MaxPool3DGrad SYCL kernel. Expects the number of threads to be equal to the
 // number of elements in the pooled output tensor (i.e. the number of elements
 // in the backprop input tensor).
@@ -1193,62 +1185,6 @@ struct LaunchMaxPooling3dGradOp<SYCLDevice, T> {
     });
   }
 };
-#ifdef __SYCL_DEVICE_ONLY__
-// Use the OpenCL atomic uint operations to provide a floating point atomic add.
-// For the device we use the atomic compare-exchange builtin to keep trying to
-// add to the memory in a thread safe way. The union is needed as these
-// builtins are not availble for floating point types, only integer types, so
-// we do the addition on the float and the memory update on the uint.
-//
-// TODO(jwlawson): Remove once we have different type accessors for SYCL buffers
-// Providing a way to cast the types of buffers or accessors has been proposed
-// as a SYCL extension, so once this is available we can use and atomic
-// accessor and remove this.
-template <>
-void SyclAtomicAdd<float>(__attribute__((address_space(1))) float* address,
-                          const float increment) {
-  union {
-    uint32_t u32;
-    float f32;
-  } next, expected, current;
-  current.f32 = *address;
-  __attribute__((address_space(1))) uint32_t* uint_addr =
-      reinterpret_cast<__attribute__((address_space(1))) uint32_t*>(address);
-  do {
-    expected.f32 = current.f32;
-    next.f32 = expected.f32 + increment;
-    current.u32 =
-        _Z14atomic_cmpxchgPVU3AS1jjj(uint_addr, expected.u32, next.u32);
-  } while (current.u32 != expected.u32);
-}
-template <>
-void SyclAtomicAdd<double>(__attribute__((address_space(1))) double* address,
-                           const double increment) {
-  union {
-    uint64_t u64;
-    double d64;
-  } next, expected, current;
-  current.d64 = *address;
-  __attribute__((address_space(1))) uint64_t* uint_addr =
-      reinterpret_cast<__attribute__((address_space(1))) uint64_t*>(address);
-  do {
-    expected.d64 = current.d64;
-    next.d64 = expected.d64 + increment;
-    current.d64 = _Z12atom_cmpxchgPVU3AS1mmm(uint_addr, expected.u64, next.u64);
-  } while (current.u64 != expected.u64);
-}
-#else
-// Provide a dummy implementation for the host compiler. This code will not be
-// seen by the SYCL device, and so should not be run.
-template <>
-void SyclAtomicAdd<float>(float* address, const float increment) {
-  LOG(FATAL) << "MaxPool3DGradSYCL should only be run on a SYCL device";
-}
-template <>
-void SyclAtomicAdd<double>(double* address, const double increment) {
-  LOG(FATAL) << "MaxPool3DGradSYCL should only be run on a SYCL device";
-}
-#endif  // __SYCL_DEVICE_ONLY__
 // MaxPool3DGradGrad SYCL kernel. Expects the number of threads to be equal to
 // the number of elements in the output backprop tensor, i.e. the number of
 // elements in the output tensor.

--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -41,7 +41,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
 typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 Pool3dParameters::Pool3dParameters(OpKernelContext* context,
                                    const std::vector<int32>& ksize,

--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -951,13 +951,13 @@ class MaxPool3DSYCL {
 
  public:
   MaxPool3DSYCL(const int depth, const int batch, const int in_planes,
-              const int in_rows, const int in_cols, const int out_planes,
-              const int out_rows, const int out_cols,
-              const std::array<int64, 3>& window,
-              const std::array<int64, 3>& stride,
-              const std::array<int64, 3>& padding,
-              const read_accessor input_accessor,
-              write_accessor output_accessor)
+                const int in_rows, const int in_cols, const int out_planes,
+                const int out_rows, const int out_cols,
+                const std::array<int64, 3>& window,
+                const std::array<int64, 3>& stride,
+                const std::array<int64, 3>& padding,
+                const read_accessor input_accessor,
+                write_accessor output_accessor)
       : p_(depth, batch, in_planes, in_rows, in_cols, out_planes, out_rows,
            out_cols, window, stride, padding),
         input_accessor_(input_accessor),
@@ -1034,8 +1034,8 @@ struct LaunchPoolingOp<SYCLDevice, T, MAX> {
       auto output_access =
           output_buffer.template get_access<cl::sycl::access::mode::write>(cgh);
       MaxPool3DSYCL<T> max_pool(depth, batch, in_planes, in_rows, in_cols,
-                              out_planes, out_rows, out_cols, window, stride,
-                              padding, input_access, output_access);
+                                out_planes, out_rows, out_cols, window, stride,
+                                padding, input_access, output_access);
 
       cgh.parallel_for(cl::sycl::range<1>(num_threads), max_pool);
     });
@@ -1074,17 +1074,17 @@ class MaxPool3DGradSYCL {
 
  public:
   MaxPool3DGradSYCL(const int depth, const int batch, const int in_planes,
-                  const int in_rows, const int in_cols,
-                  const std::array<int64, 3>& output_shape,
-                  const std::array<int64, 3>& window,
-                  const std::array<int64, 3>& stride,
-                  const std::array<int64, 3>& padding,
-                  const read_accessor input_data_accessor,
-                  const read_accessor output_data_accessor,
-                  const read_accessor input_backprop_accessor,
-                  write_accessor output_backprop_accessor)
-      : p_(depth, batch, in_planes, in_rows, in_cols, output_shape, window, stride,
-           padding),
+                    const int in_rows, const int in_cols,
+                    const std::array<int64, 3>& output_shape,
+                    const std::array<int64, 3>& window,
+                    const std::array<int64, 3>& stride,
+                    const std::array<int64, 3>& padding,
+                    const read_accessor input_data_accessor,
+                    const read_accessor output_data_accessor,
+                    const read_accessor input_backprop_accessor,
+                    write_accessor output_backprop_accessor)
+      : p_(depth, batch, in_planes, in_rows, in_cols, output_shape, window,
+           stride, padding),
         input_data_accessor_(input_data_accessor),
         output_data_accessor_(output_data_accessor),
         input_backprop_accessor_(input_backprop_accessor),
@@ -1268,10 +1268,10 @@ class MaxPool3DGradGradSYCL {
 
  public:
   MaxPool3DGradGradSYCL(const Pool3dParameters& params,
-                      const read_accessor input_data_accessor,
-                      const read_accessor output_data_accessor,
-                      const read_accessor input_backprop_accessor,
-                      write_accessor output_backprop_accessor)
+                        const read_accessor input_data_accessor,
+                        const read_accessor output_data_accessor,
+                        const read_accessor input_backprop_accessor,
+                        write_accessor output_backprop_accessor)
       : p_(params),
         input_data_accessor_(input_data_accessor),
         output_data_accessor_(output_data_accessor),
@@ -1360,15 +1360,16 @@ struct LaunchMaxPooling3dGradGradOp<SYCLDevice, T> {
       auto output_backprop_access =
           output_backprop_buffer
               .template get_access<cl::sycl::access::mode::write>(cgh);
-      MaxPool3DGradGradSYCL<T> functor(params, input_data_access,
-                                     output_data_access, input_backprop_access,
-                                     output_backprop_access);
+      MaxPool3DGradGradSYCL<T> functor(
+          params, input_data_access, output_data_access, input_backprop_access,
+          output_backprop_access);
 
       cgh.parallel_for(cl::sycl::range<1>(num_threads), functor);
     });
   }
 };
-// AvgPool3D SYCL kernel. Expects the number of threads to be equal to the number of elements in the output tensor.
+// AvgPool3D SYCL kernel. Expects the number of threads to be equal to the
+// number of elements in the output tensor.
 //
 // For each output value find the corresponding input window, and run through
 // the window accumulating the values to form an average. We divide each value
@@ -1385,13 +1386,13 @@ class AvgPool3DSYCL {
 
  public:
   AvgPool3DSYCL(const int depth, const int batch, const int in_planes,
-              const int in_rows, const int in_cols, const int out_planes,
-              const int out_rows, const int out_cols,
-              const std::array<int64, 3>& window,
-              const std::array<int64, 3>& stride,
-              const std::array<int64, 3>& padding,
-              const read_accessor input_accessor,
-              write_accessor output_accessor)
+                const int in_rows, const int in_cols, const int out_planes,
+                const int out_rows, const int out_cols,
+                const std::array<int64, 3>& window,
+                const std::array<int64, 3>& stride,
+                const std::array<int64, 3>& padding,
+                const read_accessor input_accessor,
+                write_accessor output_accessor)
       : p_(depth, batch, in_planes, in_rows, in_cols, out_planes, out_rows,
            out_cols, window, stride, padding),
         input_accessor_(input_accessor),
@@ -1468,8 +1469,8 @@ struct LaunchPoolingOp<SYCLDevice, T, AVG> {
       auto output_access =
           output_buffer.template get_access<cl::sycl::access::mode::write>(cgh);
       AvgPool3DSYCL<T> avg_pool(depth, batch, in_planes, in_rows, in_cols,
-                              out_planes, out_rows, out_cols, window, stride,
-                              padding, input_access, output_access);
+                                out_planes, out_rows, out_cols, window, stride,
+                                padding, input_access, output_access);
 
       cgh.parallel_for(cl::sycl::range<1>(num_threads), avg_pool);
     });
@@ -1496,13 +1497,13 @@ class AvgPool3DGradSYCL {
 
  public:
   AvgPool3DGradSYCL(const int depth, const int batch, const int in_planes,
-                  const int in_rows, const int in_cols,
-                  const std::array<int64, 3>& out_shape,
-                  const std::array<int64, 3>& window,
-                  const std::array<int64, 3>& stride,
-                  const std::array<int64, 3>& padding,
-                  const read_accessor input_backprop_accessor,
-                  write_accessor output_backprop_accessor)
+                    const int in_rows, const int in_cols,
+                    const std::array<int64, 3>& out_shape,
+                    const std::array<int64, 3>& window,
+                    const std::array<int64, 3>& stride,
+                    const std::array<int64, 3>& padding,
+                    const read_accessor input_backprop_accessor,
+                    write_accessor output_backprop_accessor)
       : p_(depth, batch, in_planes, in_rows, in_cols, out_shape, window, stride,
            padding),
         input_backprop_accessor_(input_backprop_accessor),
@@ -1581,7 +1582,6 @@ struct LaunchAvgPooling3dGradOp<SYCLDevice, T> {
                      const std::array<int64, 3>& padding,
                      TensorFormat data_format, Tensor* output) {
     const SYCLDevice& device = context->eigen_device<SYCLDevice>();
-    output->template flat<T>().setZero().device(device);
     const int batch = GetTensorDim(tensor_in_shape, data_format, 'N');
     const int in_planes = GetTensorDim(tensor_in_shape, data_format, '0');
     const int in_rows = GetTensorDim(tensor_in_shape, data_format, '1');
@@ -1602,9 +1602,9 @@ struct LaunchAvgPooling3dGradOp<SYCLDevice, T> {
       auto output_backprop_access =
           output_backprop_buffer
               .template get_access<cl::sycl::access::mode::write>(cgh);
-      AvgPool3DGradSYCL<T> functor(depth, batch, in_planes, in_rows, in_cols,
-                                 output_shape, window, stride, padding,
-                                 input_backprop_access, output_backprop_access);
+      AvgPool3DGradSYCL<T> functor(
+          depth, batch, in_planes, in_rows, in_cols, output_shape, window,
+          stride, padding, input_backprop_access, output_backprop_access);
 
       cgh.parallel_for(cl::sycl::range<1>(num_threads), functor);
     });

--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -931,7 +931,7 @@ struct SYCL3DPoolParams {
   const int pad_cols_;
 };
 template <typename T>
-class MaxPoolSYCL {
+class MaxPool3DSYCL {
   using write_accessor =
       cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::write,
                          cl::sycl::access::target::global_buffer>;
@@ -940,7 +940,7 @@ class MaxPoolSYCL {
                          cl::sycl::access::target::global_buffer>;
 
  public:
-  MaxPoolSYCL(const int depth, const int batch, const int in_planes,
+  MaxPool3DSYCL(const int depth, const int batch, const int in_planes,
               const int in_rows, const int in_cols, const int out_planes,
               const int out_rows, const int out_cols,
               const std::array<int64, 3>& window,
@@ -1023,7 +1023,7 @@ struct LaunchPoolingOp<SYCLDevice, T, MAX> {
           input_buffer.template get_access<cl::sycl::access::mode::read>(cgh);
       auto output_access =
           output_buffer.template get_access<cl::sycl::access::mode::write>(cgh);
-      MaxPoolSYCL<T> max_pool(depth, batch, in_planes, in_rows, in_cols,
+      MaxPool3DSYCL<T> max_pool(depth, batch, in_planes, in_rows, in_cols,
                               out_planes, out_rows, out_cols, window, stride,
                               padding, input_access, output_access);
 
@@ -1041,7 +1041,7 @@ void SyclAtomicAdd(T* address, const T increment);
 #endif  // __SYCL_DEVICE_ONLY__
 
 template <typename T>
-class MaxPoolGradSYCL {
+class MaxPool3DGradSYCL {
   using write_accessor =
       cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::write,
                          cl::sycl::access::target::global_buffer>;
@@ -1050,7 +1050,7 @@ class MaxPoolGradSYCL {
                          cl::sycl::access::target::global_buffer>;
 
  public:
-  MaxPoolGradSYCL(const int depth, const int batch, const int in_planes,
+  MaxPool3DGradSYCL(const int depth, const int batch, const int in_planes,
                   const int in_rows, const int in_cols,
                   const std::array<int64, 3>& output_shape,
                   const std::array<int64, 3>& window,
@@ -1161,7 +1161,7 @@ struct LaunchMaxPooling3dGradOp<SYCLDevice, T> {
       auto output_backprop_access =
           output_backprop_buffer
               .template get_access<cl::sycl::access::mode::write>(cgh);
-      MaxPoolGradSYCL<T> max_pool(
+      MaxPool3DGradSYCL<T> max_pool(
           depth, batch, in_planes, in_rows, in_cols, out, window, stride,
           padding, input_data_access, output_data_access, input_backprop_access,
           output_backprop_access);
@@ -1217,7 +1217,7 @@ void SyclAtomicAdd<double>(double* address, const double increment) {
 }
 #endif  // __SYCL_DEVICE_ONLY__
 template <typename T>
-class MaxPoolGradGradSYCL {
+class MaxPool3DGradGradSYCL {
   using write_accessor =
       cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::write,
                          cl::sycl::access::target::global_buffer>;
@@ -1226,7 +1226,7 @@ class MaxPoolGradGradSYCL {
                          cl::sycl::access::target::global_buffer>;
 
  public:
-  MaxPoolGradGradSYCL(const Pool3dParameters& params,
+  MaxPool3DGradGradSYCL(const Pool3dParameters& params,
                       const read_accessor input_data_accessor,
                       const read_accessor output_data_accessor,
                       const read_accessor input_backprop_accessor,
@@ -1319,7 +1319,7 @@ struct LaunchMaxPooling3dGradGradOp<SYCLDevice, T> {
       auto output_backprop_access =
           output_backprop_buffer
               .template get_access<cl::sycl::access::mode::write>(cgh);
-      MaxPoolGradGradSYCL<T> functor(params, input_data_access,
+      MaxPool3DGradGradSYCL<T> functor(params, input_data_access,
                                      output_data_access, input_backprop_access,
                                      output_backprop_access);
 
@@ -1328,7 +1328,7 @@ struct LaunchMaxPooling3dGradGradOp<SYCLDevice, T> {
   }
 };
 template <typename T>
-class AvgPoolSYCL {
+class AvgPool3DSYCL {
   using write_accessor =
       cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::write,
                          cl::sycl::access::target::global_buffer>;
@@ -1337,7 +1337,7 @@ class AvgPoolSYCL {
                          cl::sycl::access::target::global_buffer>;
 
  public:
-  AvgPoolSYCL(const int depth, const int batch, const int in_planes,
+  AvgPool3DSYCL(const int depth, const int batch, const int in_planes,
               const int in_rows, const int in_cols, const int out_planes,
               const int out_rows, const int out_cols,
               const std::array<int64, 3>& window,
@@ -1420,7 +1420,7 @@ struct LaunchPoolingOp<SYCLDevice, T, AVG> {
           input_buffer.template get_access<cl::sycl::access::mode::read>(cgh);
       auto output_access =
           output_buffer.template get_access<cl::sycl::access::mode::write>(cgh);
-      AvgPoolSYCL<T> avg_pool(depth, batch, in_planes, in_rows, in_cols,
+      AvgPool3DSYCL<T> avg_pool(depth, batch, in_planes, in_rows, in_cols,
                               out_planes, out_rows, out_cols, window, stride,
                               padding, input_access, output_access);
 
@@ -1429,7 +1429,7 @@ struct LaunchPoolingOp<SYCLDevice, T, AVG> {
   }
 };
 template <typename T>
-class AvgPoolGradSYCL {
+class AvgPool3DGradSYCL {
   using write_accessor =
       cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::write,
                          cl::sycl::access::target::global_buffer>;
@@ -1438,7 +1438,7 @@ class AvgPoolGradSYCL {
                          cl::sycl::access::target::global_buffer>;
 
  public:
-  AvgPoolGradSYCL(const int depth, const int batch, const int in_planes,
+  AvgPool3DGradSYCL(const int depth, const int batch, const int in_planes,
                   const int in_rows, const int in_cols,
                   const std::array<int64, 3>& out_shape,
                   const std::array<int64, 3>& window,
@@ -1545,7 +1545,7 @@ struct LaunchAvgPooling3dGradOp<SYCLDevice, T> {
       auto output_backprop_access =
           output_backprop_buffer
               .template get_access<cl::sycl::access::mode::write>(cgh);
-      AvgPoolGradSYCL<T> functor(depth, batch, in_planes, in_rows, in_cols,
+      AvgPool3DGradSYCL<T> functor(depth, batch, in_planes, in_rows, in_cols,
                                  output_shape, window, stride, padding,
                                  input_backprop_access, output_backprop_access);
 

--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -708,9 +708,8 @@ class MaxPooling3dGradGradOp : public OpKernel {
                             padding_, data_format_, tensor_in.shape()};
 
     Tensor* output = nullptr;
-    //OP_REQUIRES_OK(context, context->forward_input_or_allocate_output({2},
-    OP_REQUIRES_OK(context, context->allocate_output(
-       0, tensor_out.shape(), &output));
+    OP_REQUIRES_OK(context, context->forward_input_or_allocate_output(
+                                {2}, 0, tensor_out.shape(), &output));
 
     LaunchMaxPooling3dGradGradOp<Device, T>::launch(
         context, params, tensor_in, tensor_out, out_grad_backprop, output);

--- a/tensorflow/core/util/sycl_util.h
+++ b/tensorflow/core/util/sycl_util.h
@@ -1,0 +1,98 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_USE_SYCL
+#error This file contains SYCL specific code and should only be included when \
+building with SYCL support.
+#endif
+
+#ifndef TENSORFLOW_CORE_UTIL_SYCL_UTIL_H_
+#define TENSORFLOW_CORE_UTIL_SYCL_UTIL_H_
+
+namespace tensorflow {
+
+// Need an atomic add for the MaxPoolGrad and MaxPool3DGrad kernels.
+//
+// For the device, this needs a pointer to global memory which isn't understood
+// by the host. The host should never be calling this method, but we provide
+// the header so that the host compiler can compile the functor.
+#ifdef __SYCL_DEVICE_ONLY__
+template <typename T>
+void SyclAtomicAdd(__attribute__((address_space(1))) T* address,
+                   const T increment);
+#else
+template <typename T>
+void SyclAtomicAdd(T* address, const T increment);
+#endif  // __SYCL_DEVICE_ONLY__
+
+#ifdef __SYCL_DEVICE_ONLY__
+// Use the OpenCL atomic uint operations to provide a floating point atomic add.
+// For the device we use the atomic compare-exchange builtin to keep trying to
+// add to the memory in a thread safe way. The union is needed as these
+// builtins are not availble for floating point types, only integer types, so
+// we do the addition on the float and the memory update on the uint.
+//
+// TODO(jwlawson): Remove once we have different type accessors for SYCL buffers
+// Providing a way to cast the types of buffers or accessors has been proposed
+// as a SYCL extension, so once this is available we can use an atomic
+// accessor and remove this.
+template <>
+void SyclAtomicAdd<float>(__attribute__((address_space(1))) float* address,
+                          const float increment) {
+  union {
+    uint32_t u32;
+    float f32;
+  } next, expected, current;
+  current.f32 = *address;
+  __attribute__((address_space(1))) uint32_t* uint_addr =
+      reinterpret_cast<__attribute__((address_space(1))) uint32_t*>(address);
+  do {
+    expected.f32 = current.f32;
+    next.f32 = expected.f32 + increment;
+    current.u32 =
+        _Z14atomic_cmpxchgPVU3AS1jjj(uint_addr, expected.u32, next.u32);
+  } while (current.u32 != expected.u32);
+}
+template <>
+void SyclAtomicAdd<double>(__attribute__((address_space(1))) double* address,
+                           const double increment) {
+  union {
+    uint64_t u64;
+    double d64;
+  } next, expected, current;
+  current.d64 = *address;
+  __attribute__((address_space(1))) uint64_t* uint_addr =
+      reinterpret_cast<__attribute__((address_space(1))) uint64_t*>(address);
+  do {
+    expected.d64 = current.d64;
+    next.d64 = expected.d64 + increment;
+    current.d64 = _Z12atom_cmpxchgPVU3AS1mmm(uint_addr, expected.u64, next.u64);
+  } while (current.u64 != expected.u64);
+}
+#else
+// Provide a dummy implementation for the host compiler. This code will not be
+// seen by the SYCL device, and so should not be run.
+template <>
+void SyclAtomicAdd<float>(float* address, const float increment) {
+  LOG(FATAL) << "MaxPool3DGradSYCL should only be run on a SYCL device";
+}
+template <>
+void SyclAtomicAdd<double>(double* address, const double increment) {
+  LOG(FATAL) << "MaxPool3DGradSYCL should only be run on a SYCL device";
+}
+#endif  // __SYCL_DEVICE_ONLY__
+
+}  // namespace tensorflow
+#endif  // TENSORFLOW_CORE_UTIL_SYCL_UTIL_H_


### PR DESCRIPTION
Provides a number of SYCL kernels for all 3D pooling operations. Each kernel is similar to the corresponding CUDA kernel, but I have made some assumptions on the number of threads which simplifies the code a little.

The atomic adds required for MaxPool3DGrad are currently implemented using the OpenCL builtins and should be replaced once SYCL accessors of different types are available.

`//tensorflow/python/kernel_test/pooling_ops_3d_test` now passes.