### PR TITLE
Improve SYCL config for Tensorflow

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -428,7 +428,7 @@ cc_binary(
         "//tensorflow/c:exported_symbols.lds",
         "//tensorflow/c:version_script.lds",
         "//tensorflow/core:tensorflow",
-    ],
+    ] + if_sycl[("@local_sycl_config//sycl:syclrt")],
 )
 
 cc_binary(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1860,7 +1860,7 @@ cc_library(
         ":lib_internal",
         ":proto_text",
         "//third_party/eigen3",
-        "@local_config_sycl//sycl:sycl",
+        "@local_config_sycl//sycl:sycl_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -236,7 +236,7 @@ cc_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//third_party/eigen3",
-    ],
+    ] + if_sycl([ "//tensorflow/core:sycl_runtime"]),
 )
 
 cc_library(

--- a/third_party/sycl/crosstool/computecpp.tpl
+++ b/third_party/sycl/crosstool/computecpp.tpl
@@ -15,7 +15,7 @@ COMPUTECPP_INCLUDE = COMPUTECPP_ROOT + 'include'
 
 def main():
   remove_flags = ('-Wl,--no-undefined', '-Wno-unused-but-set-variable', '-Wignored-attributes')
-    # remove -fsamotoze-coverage from string with g++
+  # remove -fsanitize-coverage from string with g++
   if 'g++' in CPU_CXX_COMPILER:
     remove_flags += ('-fsanitize-coverage',)
   compiler_flags = [flag for flag in sys.argv[1:] if not flag.startswith(remove_flags)]
@@ -79,7 +79,7 @@ def main():
                                       '-Xclang', '-cl-denorms-are-zero', '-Xclang', '-cl-fp32-correctly-rounded-divide-sqrt']
   # disable flags enabling SIMD instructions
   computecpp_device_compiler_flags += [flag for flag in compiler_flags if \
-    not any(x in flag.lower() for x in ('-fsanitize', '=native', '=core2', 'msse', 'vectorize', 'mavx', 'mmmx', 'm3dnow', 'fma'))]
+    not any(x in flag.lower() for x in ('-fsanitize', '-fno-canonical-system-headers', '=native', '=core2', 'msse', 'vectorize', 'mavx', 'mmmx', 'm3dnow', 'fma'))]
 
   x = call([COMPUTECPP_DRIVER] + computecpp_device_compiler_flags)
   if x == 0:

--- a/third_party/sycl/sycl/BUILD.tpl
+++ b/third_party/sycl/sycl/BUILD.tpl
@@ -40,6 +40,5 @@ cc_library(
     name = "sycl",
     deps = if_sycl([
         ":sycl_headers",
-        ":syclrt",
     ]),
 )


### PR DESCRIPTION
Only libtensorflow attempts to link against libComputeCpp.so now,
other targets should only utilise the headers. Added more if_sycl
statements to BUILD files.