### PR TITLE
[OpenCL] Uses managed_session in parallel_reader tests

### DIFF
--- a/tensorflow/contrib/slim/python/slim/data/parallel_reader_test.py
+++ b/tensorflow/contrib/slim/python/slim/data/parallel_reader_test.py
@@ -57,8 +57,7 @@ class ParallelReaderTest(test.TestCase):
     num_reads = 50
 
     sv = supervisor.Supervisor(logdir=self.get_temp_dir())
-    with sv.prepare_or_wait_for_session() as sess:
-      sv.start_queue_runners(sess)
+    with sv.managed_session() as sess:
 
       for _ in range(num_reads):
         current_key, _ = sess.run([key, value])
@@ -101,8 +100,7 @@ class ParallelReadTest(test.TestCase):
         self._tfrecord_paths, reader_class=io_ops.TFRecordReader, num_readers=3)
 
     sv = supervisor.Supervisor(logdir=self.get_temp_dir())
-    with sv.prepare_or_wait_for_session() as sess:
-      sv.start_queue_runners(sess)
+    with sv.managed_session() as sess:
 
       flowers = 0
       num_reads = 100


### PR DESCRIPTION
The Session from a tensorflow.python.training.Supervisor should be obtained from managed_session, rather than prepare_or_wait_for_session. The managed session will ensure that the service threads are started when the session is created and that the threads are closed down properly, the session is destroyed and all resources are released.

When the prepare_or_wait_for_session method is used to create a session, the user is responsible for all of this. These tests did not contain any shutdown code previously and so the session was not being destroyed properly.

These tests should not be testing the handling of an incomplete shutdown, if that should be tested then it is probably better to have this in the supervisor_test test cases.