### PR TITLE
[OpenCL] Adds buffer size tracking to SYCL allocator

### DIFF
--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -71,6 +71,11 @@ void SYCLAllocator::GetStats(AllocatorStats* stats) {
   *stats = stats_;
 }
 
+size_t SYCLAllocator::RequestedSize(void* ptr) {
+  const auto& buffer = sycl_device_->get_sycl_buffer(ptr);
+  return buffer.get_size();
+}
+
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_USE_SYCL

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -39,6 +39,12 @@ class SYCLAllocator : public Allocator {
   void Synchronize() { sycl_device_->synchronize(); }
   bool Ok() { return sycl_device_->ok(); }
   void GetStats(AllocatorStats* stats) override;
+  // The SYCL buffers keep track of their size, so we already have tracking.
+  bool TracksAllocationSizes() override { return true; }
+  // Get the size of the corresponding SYCL buffer.
+  // Implementing this also provides an implementation of
+  // AllocatedSize(void* ptr) by default.
+  size_t RequestedSize(void* ptr) override;
   Eigen::SyclDevice* getSyclDevice() { return sycl_device_; }
  private:
   Eigen::SyclDevice *sycl_device_;  // owned


### PR DESCRIPTION
The SYCL buffers underlying tensors already keep track of their sizes, so we can easily provide this tracking information for debugging purposes.

This fixes some of the problems with #75 but does not fully allow the test to pass. It still fails with the same error `cost_models.size() == 1 (2 vs. 1)` that also affects CUDA.