### PR TITLE
[OpenCL] Fixes expected cost models with devices

### DIFF
--- a/tensorflow/core/common_runtime/direct_session_with_tracking_alloc_test.cc
+++ b/tensorflow/core/common_runtime/direct_session_with_tracking_alloc_test.cc
@@ -138,7 +138,7 @@ TEST(DirectSessionWithTrackingAllocTest, CostModelWarmup) {
   DirectSession* ds = static_cast<DirectSession*>(session.get());
   CostModelManager::CostModelMap cost_models;
   ds->ExportCostModels(&cost_models);
-  CHECK_EQ(cost_models.size(), 1);
+  CHECK_GE(cost_models.size(), 1);
   const CostModel* cm = (*cost_models.begin()).second;
   EXPECT_EQ(measure_steps, cm->GetUpdateTimes());
 }


### PR DESCRIPTION
The aim of this test is to ensure that there is at least one cost model (that of the CPU), as if there are no cost models then the test should fail and there is no point in trying to run the other tests on the cost
model.

The number of cost models provided by a session should matches the number of devices used by that session. When additional devices are present there will be more than one cost model, so we should not be checking for equality, but rather that the number of cost models is at least one.