### PR TITLE
[OpenCL] Fixes SYCL registration for MapStageOp

### DIFF
--- a/tensorflow/core/kernels/map_stage_op.cc
+++ b/tensorflow/core/kernels/map_stage_op.cc
@@ -550,12 +550,17 @@ REGISTER_KERNEL_BUILDER(Name("OrderedMapStage")
 #endif // GOOGLE_CUDA
 
 #ifdef TENSORFLOW_USE_SYCL
-REGISTER_KERNEL_BUILDER(Name("MapStage").HostMemory("key").Device(DEVICE_SYCL),
+REGISTER_KERNEL_BUILDER(Name("MapStage")
+                            .HostMemory("key")
+                            .HostMemory("indices")
+                            .Device(DEVICE_SYCL),
                         MapStageOp<false>);
-REGISTER_KERNEL_BUILDER(
-    Name("OrderedMapStage").HostMemory("key").Device(DEVICE_SYCL),
-    MapStageOp<true>);
-#endif // TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("OrderedMapStage")
+                            .HostMemory("key")
+                            .HostMemory("indices")
+                            .Device(DEVICE_SYCL),
+                        MapStageOp<true>);
+#endif  // TENSORFLOW_USE_SYCL
 
 template <bool Ordered>
 class MapUnstageOp : public OpKernel {

--- a/tensorflow/python/kernel_tests/map_stage_op_test.py
+++ b/tensorflow/python/kernel_tests/map_stage_op_test.py
@@ -108,8 +108,8 @@ class MapStageTest(test.TestCase):
       with ops.device(gpu_dev):
         stager = data_flow_ops.MapStagingArea([dtypes.float32])
         y = stager.put(1, [v], [0])
-        self.assertEqual(y.device, '/device:GPU:0' if gpu_dev
-                                                   else gpu_dev)
+        expected_name = gpu_dev if 'gpu' not in gpu_dev else '/device:GPU:0'
+        self.assertEqual(y.device, expected_name)
       with ops.device('/cpu:0'):
         _, x = stager.get(1)
         y = stager.peek(1)


### PR DESCRIPTION
As the MapStageOp is actually run on the host, we need to ensure that both the 'key' and 'indices' tensors are in host memory. This now mirrors what CUDA is doing.

Also fixes device name comparison map_stage_op_test,  by changing the expected device name string, as the device name could be '/device:SYCL:0' or '/device:GPU:0'. The CUDA device name reported by test_util is in the form '/gpu:0', while the device name used in the nodes looks like '/device:GPU:0'. When running on CUDA we need to change the expected device name accordingly,
however this isn't a problem on SYCL.