### PR TITLE
[OpenCL] Adding SYCL kernel for Tile functor

### DIFF
--- a/tensorflow/core/kernels/tile_functor_cpu.cc
+++ b/tensorflow/core/kernels/tile_functor_cpu.cc
@@ -21,26 +21,21 @@ limitations under the License.
 
 namespace tensorflow {
 
+namespace functor {
+// Need to use a function object so we can provide partial specializations for
+// different devices.
+template <typename Device, typename T>
+struct TileFunctor {
+  void operator()(const Device& d, Tensor* out, const Tensor& in);
+};
+}
+
 namespace internal {
 
 template <typename Device, typename T>
 void TileSimple(const Device& d, Tensor* out, const Tensor& in) {
-  const int ndims = in.dims();
-  const int64 nelem = out->NumElements();
-  gtl::InlinedVector<int64, 8> in_strides = ComputeStride<int64>(in.shape());
-  gtl::InlinedVector<int64, 8> out_strides = ComputeStride<int64>(out->shape());
-  const T* p = in.flat<T>().data();
-  T* q = out->flat<T>().data();
-
-  for (int64 o_idx = 0; o_idx < nelem; ++o_idx) {
-    int64 i_idx = 0;
-    int64 t = o_idx;
-    for (int i = 0; i < ndims; ++i) {
-      i_idx += t / out_strides[i] % in.dim_size(i) * in_strides[i];
-      t %= out_strides[i];
-    }
-    q[o_idx] = p[i_idx];
-  }
+  functor::TileFunctor<Device, T> functor;
+  functor(d, out, in);
 }
 
 }  // end namespace internal
@@ -48,6 +43,29 @@ void TileSimple(const Device& d, Tensor* out, const Tensor& in) {
 namespace functor {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
+
+template <typename T>
+struct TileFunctor<CPUDevice, T> {
+  void operator()(const CPUDevice& d, Tensor* out, const Tensor& in) {
+    const int ndims = in.dims();
+    const int64 nelem = out->NumElements();
+    gtl::InlinedVector<int64, 8> in_strides = ComputeStride<int64>(in.shape());
+    gtl::InlinedVector<int64, 8> out_strides =
+        ComputeStride<int64>(out->shape());
+    const T* p = in.flat<T>().data();
+    T* q = out->flat<T>().data();
+
+    for (int64 o_idx = 0; o_idx < nelem; ++o_idx) {
+      int64 i_idx = 0;
+      int64 t = o_idx;
+      for (int i = 0; i < ndims; ++i) {
+        i_idx += t / out_strides[i] % in.dim_size(i) * in_strides[i];
+        t %= out_strides[i];
+      }
+      q[o_idx] = p[i_idx];
+    }
+  }
+};
 
 // Register functors used for Tile functor.
 #define DEFINE_TYPE(T) template struct Tile<CPUDevice, T>;
@@ -68,6 +86,85 @@ TF_CALL_string(DEFINE_TYPE);
 
 #ifdef TENSORFLOW_USE_SYCL
 typedef Eigen::SyclDevice SYCLDevice;
+// SYCL kernel to copy tiles from the input to the output. Expects the number of
+// threads to be the number of elements in the output tensor.
+template <typename T>
+struct TileSYCL {
+  using write_accessor =
+      cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::write,
+                         cl::sycl::access::target::global_buffer>;
+  using read_accessor =
+      cl::sycl::accessor<uint8_t, 1, cl::sycl::access::mode::read,
+                         cl::sycl::access::target::global_buffer>;
+  using stride_read_accessor =
+      cl::sycl::accessor<int64, 2, cl::sycl::access::mode::read,
+                         cl::sycl::access::target::global_buffer>;
+  TileSYCL(int ndims, const read_accessor input,
+           const stride_read_accessor strides, write_accessor output)
+      : ndims_(ndims),
+        input_accessor_(input),
+        stride_accessor_(strides),
+        output_accessor_(output) {}
+
+  void operator()(cl::sycl::item<1> id) {
+    const T* input = ConvertToActualTypeSycl(T, input_accessor_);
+    T* output = ConvertToActualTypeSycl(T, output_accessor_);
+
+    const int64 o_idx = id.get_linear_id();
+    int64 i_idx = 0;
+    int64 t = o_idx;
+    for (int i = 0; i < ndims_; ++i) {
+      i_idx += ((t / stride_accessor_[cl::sycl::id<2>(1, i)]) %
+                stride_accessor_[cl::sycl::id<2>(2, i)]) *
+               stride_accessor_[cl::sycl::id<2>(0, i)];
+      t %= stride_accessor_[cl::sycl::id<2>(1, i)];
+    }
+    output[o_idx] = input[i_idx];
+  }
+
+ private:
+  const int ndims_;
+  const read_accessor input_accessor_;
+  const stride_read_accessor stride_accessor_;
+  write_accessor output_accessor_;
+};
+
+template <typename T>
+struct TileFunctor<SYCLDevice, T> {
+  void operator()(const SYCLDevice& d, Tensor* out, const Tensor& in) {
+    auto input_buffer = d.get_sycl_buffer(in.template flat<T>().data());
+    auto output_buffer = d.get_sycl_buffer(out->template flat<T>().data());
+    const int ndims = in.dims();
+    const int64 nelem = out->NumElements();
+    gtl::InlinedVector<int64, 8> in_strides = ComputeStride<int64>(in.shape());
+    gtl::InlinedVector<int64, 8> out_strides =
+        ComputeStride<int64>(out->shape());
+
+    // Allocate a temporary [3 x ndims] SYCL buffer.
+    // This holds the input strides, output strides and the input dimensions
+    // needed for the kernel to compute the tile indices.
+    cl::sycl::buffer<int64, 2> stride_buffer(cl::sycl::range<2>(3, ndims));
+    auto stride_host = stride_buffer.template get_access<
+        cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>();
+    for (int i = 0; i < ndims; ++i) {
+      stride_host[cl::sycl::id<2>(0, i)] = in_strides[i];
+      stride_host[cl::sycl::id<2>(1, i)] = out_strides[i];
+      stride_host[cl::sycl::id<2>(2, i)] = in.shape().dim_size(i);
+    }
+
+    d.sycl_queue().submit([&](cl::sycl::handler& cgh) {
+      auto input_access =
+          input_buffer.template get_access<cl::sycl::access::mode::read>(cgh);
+      auto output_access =
+          output_buffer.template get_access<cl::sycl::access::mode::write>(cgh);
+      auto stride_access =
+          stride_buffer.template get_access<cl::sycl::access::mode::read>(cgh);
+      TileSYCL<T> functor(ndims, input_access, stride_access, output_access);
+
+      cgh.parallel_for(cl::sycl::range<1>(nelem), functor);
+    });
+  }
+};
 
 #define DEFINE_TYPE(T) template struct Tile<SYCLDevice, T>;
 
@@ -80,7 +177,7 @@ TF_CALL_int16(DEFINE_TYPE);
 TF_CALL_int64(DEFINE_TYPE);
 
 #undef DEFINE_TYPE
-#endif // TENSORFLOW_USE_SYCL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // end namespace functor
 }  // end namespace tensorflow


### PR DESCRIPTION
The TileOP uses an Eigen kernel for Tensors with a small number of dimensions, however it falls back on a custom kernel for larger dimensions. This requires a separate SYCL kernel to handle these larger
cases.