### PR TITLE
[OpenCL] Fixes SYCL Conv2d Backprop ops registration

### DIFF
--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -915,13 +915,13 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropFilter")
 #endif  // GOOGLE_CUDA
 
 #ifdef TENSORFLOW_USE_SYCL
-#define REGISTER_SYCL_KERNELS(T)                                         \
-  REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropFilter")                   \
-                              .Device(DEVICE_SYCL)                       \
-                              .Label("eigen_tensor")                     \
-                              .TypeConstraint<T>("T"),                   \
+#define REGISTER_SYCL_KERNELS(T)                           \
+  REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropFilter")     \
+                              .Device(DEVICE_SYCL)         \
+                              .TypeConstraint<T>("T")      \
+                              .HostMemory("filter_sizes"), \
                           Conv2DFastBackpropFilterOp<SYCLDevice, T>);
-REGISTER_SYCL_KERNELS(float);
+TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNELS);
 #undef REGISTER_SYCL_KERNELS
 #endif  // TENSORFLOW_USE_SYCL
 


### PR DESCRIPTION
Ensures that the Conv2dBackpropInput and Conv2dBackpropFilter ops are registered for SYCL.

These just use Eigen to do the computations (see conv2d.h and conv_grad_filter_ops.cc), however they do seem to be really slow.