### PR TITLE
[OpenCL] Fixes device path to name with many colons

### DIFF
--- a/tensorflow/python/debug/lib/debug_data.py
+++ b/tensorflow/python/debug/lib/debug_data.py
@@ -379,7 +379,8 @@ def device_path_to_device_name(device_dir):
   path_items = os.path.basename(device_dir)[
       len(METADATA_FILE_PREFIX) + len(DEVICE_TAG):].split(",")
   return "/".join([
-      path_item.replace("_", ":", 1) for path_item in path_items])
+      path_item.replace("device_", "device:").replace("_", ":", 1)
+      for path_item in path_items])
 
 
 class DebugTensorDatum(object):


### PR DESCRIPTION
The device path is constructed from a device name by replacing all colons with underscores. Some device names contain more than one colon, for example `device:SYCL:0` which gives a path `device_SYCL_0`. The previous code would not convert this back to the original device name, but rather to `device:SYCL_0`.

An alternative fix would be to convert all underscores to colons in the device name (i.e. remove the restriction inside `replace("_", ":", 1)` to just `replace("_", ":")`), however this would cause problems if there are any device names which are meant to contain underscores.

I'm not too sure what would be the best way of doing this.