### PR TITLE
[OpenCL] Fixed failure in conv_ops_test

### DIFF
--- a/tensorflow/core/kernels/conv_ops_test.cc
+++ b/tensorflow/core/kernels/conv_ops_test.cc
@@ -207,7 +207,11 @@ class FusedResizePadConvOpTest : public OpsTestBase {
     std::vector<Tensor> fused_tensors;
     TF_ASSERT_OK(session->Run({}, {"fused_conv"}, {}, &fused_tensors));
 
+#ifdef TENSORFLOW_USE_SYCL
+    test::ExpectTensorNear<float>(unfused_tensors[0], fused_tensors[0], 5e-3);
+#else
     test::ExpectTensorNear<float>(unfused_tensors[0], fused_tensors[0], 1e-5);
+#endif  // TENSORFLOW_USE_SYCL
   }
 
   void CompareFusedPadOnlyAndSeparate(int input_width, int input_height,


### PR DESCRIPTION
The failure has to do with SYCL having a lower float precision than CPU.