### PR TITLE
[OpenCL] Fix allocator destruction race condition

### DIFF
--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -72,6 +72,9 @@ void SYCLAllocator::GetStats(AllocatorStats* stats) {
 }
 
 size_t SYCLAllocator::RequestedSize(void* ptr) {
+  if(!sycl_device_) {
+    return 0;
+  }
   const auto& buffer = sycl_device_->get_sycl_buffer(ptr);
   return buffer.get_size();
 }

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -57,11 +57,11 @@ void *SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
 }
 
 void SYCLAllocator::DeallocateRaw(void *ptr) {
-  const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
-  const std::size_t dealloc_size = buffer_to_delete.get_range().size();
-  mutex_lock lock(mu_);
-  stats_.bytes_in_use -= dealloc_size;
   if (sycl_device_) {
+    const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
+    const std::size_t dealloc_size = buffer_to_delete.get_range().size();
+    mutex_lock lock(mu_);
+    stats_.bytes_in_use -= dealloc_size;
     sycl_device_->deallocate(ptr);
   }
 }

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -19,7 +19,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-SYCLAllocator::SYCLAllocator(Eigen::QueueInterface *queue)
+SYCLAllocator::SYCLAllocator(Eigen::QueueInterface* queue)
     : sycl_device_(new Eigen::SyclDevice(queue)) {
   cl::sycl::queue& sycl_queue = sycl_device_->sycl_queue();
   const cl::sycl::device& device = sycl_queue.get_device();
@@ -28,14 +28,14 @@ SYCLAllocator::SYCLAllocator(Eigen::QueueInterface *queue)
 }
 
 SYCLAllocator::~SYCLAllocator() {
-  if(sycl_device_) {
+  if (sycl_device_) {
     delete sycl_device_;
   }
 }
 
 string SYCLAllocator::Name() { return "device:SYCL"; }
 
-void *SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
+void* SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
   assert(sycl_device_);
   if (num_bytes == 0) {
     // Cannot allocate no bytes in SYCL, so instead allocate a single byte
@@ -56,7 +56,7 @@ void *SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
   return p;
 }
 
-void SYCLAllocator::DeallocateRaw(void *ptr) {
+void SYCLAllocator::DeallocateRaw(void* ptr) {
   if (sycl_device_) {
     const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
     const std::size_t dealloc_size = buffer_to_delete.get_range().size();

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -46,6 +46,12 @@ class SYCLAllocator : public Allocator {
   // AllocatedSize(void* ptr) by default.
   size_t RequestedSize(void* ptr) override;
   Eigen::SyclDevice* getSyclDevice() { return sycl_device_; }
+  // Clear the SYCL device used by the Allocator
+  void ClearSYCLDevice() {
+    delete sycl_device_;
+    sycl_device_ = nullptr;
+  }
+
  private:
   Eigen::SyclDevice *sycl_device_;  // owned
 

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -29,11 +29,11 @@ namespace tensorflow {
 
 class SYCLAllocator : public Allocator {
  public:
-  SYCLAllocator(Eigen::QueueInterface *queue);
+  SYCLAllocator(Eigen::QueueInterface* queue);
   virtual ~SYCLAllocator() override;
   string Name() override;
-  void *AllocateRaw(size_t alignment, size_t num_bytes) override;
-  void DeallocateRaw(void *ptr) override;
+  void* AllocateRaw(size_t alignment, size_t num_bytes) override;
+  void DeallocateRaw(void* ptr) override;
 
   virtual bool ShouldAllocateEmptyTensors() override final { return true; }
   void Synchronize() { sycl_device_->synchronize(); }
@@ -53,7 +53,7 @@ class SYCLAllocator : public Allocator {
   }
 
  private:
-  Eigen::SyclDevice *sycl_device_;  // owned
+  Eigen::SyclDevice* sycl_device_;  // owned
 
   mutable mutex mu_;
   AllocatorStats stats_ GUARDED_BY(mu_);

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -36,8 +36,12 @@ class SYCLAllocator : public Allocator {
   void DeallocateRaw(void* ptr) override;
 
   virtual bool ShouldAllocateEmptyTensors() override final { return true; }
-  void Synchronize() { sycl_device_->synchronize(); }
-  bool Ok() { return sycl_device_->ok(); }
+  void Synchronize() {
+    if (sycl_device_) {
+      sycl_device_->synchronize();
+    }
+  }
+  bool Ok() { return sycl_device_ && sycl_device_->ok(); }
   void GetStats(AllocatorStats* stats) override;
   // The SYCL buffers keep track of their size, so we already have tracking.
   bool TracksAllocationSizes() override { return true; }

--- a/tensorflow/core/common_runtime/sycl/sycl_device.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.cc
@@ -22,16 +22,6 @@ limitations under the License.
 #include "tensorflow/core/platform/tracing.h"
 
 namespace tensorflow {
-std::mutex GSYCLInterface::mutex_;
-GSYCLInterface *GSYCLInterface::s_instance = 0;
-
-void ShutdownSycl() {
-  GSYCLInterface::Reset();
-}
-
-void SYCLDevice::RegisterDevice() {
-    atexit(ShutdownSycl);
-}
 
 SYCLDevice::~SYCLDevice() {}
 

--- a/tensorflow/core/common_runtime/sycl/sycl_device.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.cc
@@ -25,7 +25,7 @@ namespace tensorflow {
 
 SYCLDevice::~SYCLDevice() {}
 
-void SYCLDevice::Compute(OpKernel *op_kernel, OpKernelContext *context) {
+void SYCLDevice::Compute(OpKernel* op_kernel, OpKernelContext* context) {
   assert(context);
   if (port::Tracing::IsActive()) {
     // TODO(pbar) We really need a useful identifier of the graph node.
@@ -36,16 +36,16 @@ void SYCLDevice::Compute(OpKernel *op_kernel, OpKernelContext *context) {
   op_kernel->Compute(context);
 }
 
-Allocator *SYCLDevice::GetAllocator(AllocatorAttributes attr) {
+Allocator* SYCLDevice::GetAllocator(AllocatorAttributes attr) {
   if (attr.on_host())
     return cpu_allocator_;
   else
     return sycl_allocator_;
 }
 
-Status SYCLDevice::MakeTensorFromProto(const TensorProto &tensor_proto,
+Status SYCLDevice::MakeTensorFromProto(const TensorProto& tensor_proto,
                                        const AllocatorAttributes alloc_attrs,
-                                       Tensor *tensor) {
+                                       Tensor* tensor) {
   AllocatorAttributes attr;
   attr.set_on_host(true);
   Allocator* host_alloc = GetAllocator(attr);
@@ -69,18 +69,18 @@ Status SYCLDevice::MakeTensorFromProto(const TensorProto &tensor_proto,
     }
 
     device_context_->CopyCPUTensorToDevice(
-        &parsed, this, &copy, [&status](const Status &s) { status = s; });
+        &parsed, this, &copy, [&status](const Status& s) { status = s; });
     *tensor = copy;
   }
   return status;
 }
 
-Status SYCLDevice::FillContextMap(const Graph *graph,
-                                  DeviceContextMap *device_context_map) {
+Status SYCLDevice::FillContextMap(const Graph* graph,
+                                  DeviceContextMap* device_context_map) {
   // Fill in the context map.  It is OK for this map to contain
   // duplicate DeviceContexts so long as we increment the refcount.
   device_context_map->resize(graph->num_node_ids());
-  for (Node *n : graph->nodes()) {
+  for (Node* n : graph->nodes()) {
     device_context_->Ref();
     (*device_context_map)[n->id()] = device_context_;
   }

--- a/tensorflow/core/common_runtime/sycl/sycl_device.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.h
@@ -76,7 +76,14 @@ class GSYCLInterface
 
         for (auto p : m_sycl_allocator_) {
           p->Synchronize();
-          delete p;
+          p->ClearSYCLDevice();
+          // Cannot delete the Allocator instances, as the Allocator lifetime
+          // needs to exceed any Tensor created by it. There is no way of
+          // knowing when all Tensors have been deallocated, as they are
+          // RefCounted and wait until all instances of a Tensor have been
+          // destroyed before calling Allocator.Deallocate. This could happen at
+          // program exit, which can set up a race condition between destroying
+          // Tensors and Allocators when the program is cleaning up.
         }
         m_sycl_allocator_.clear();
 

--- a/tensorflow/core/common_runtime/sycl/sycl_device.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.h
@@ -31,8 +31,7 @@ class GSYCLInterface {
   std::vector<Eigen::QueueInterface*> m_queue_interface_;  // owned
   std::vector<Allocator*> m_cpu_allocator_;                // not owned
   std::vector<SYCLAllocator*> m_sycl_allocator_;           // owned
-  std::vector<SYCLDeviceContext*> m_sycl_context_;         // owned
-
+  std::vector<SYCLDeviceContext*> m_sycl_context_;         // ref counted
   GSYCLInterface() {
     bool found_device = false;
     auto device_list = Eigen::get_sycl_supported_devices();
@@ -204,9 +203,9 @@ class SYCLDevice : public LocalDevice {
   Status Sync() override;
 
  private:
-  Allocator* cpu_allocator_;       // not owned
-  SYCLAllocator* sycl_allocator_;  // not owned
-  SYCLDeviceContext* device_context_;
+  Allocator* cpu_allocator_;           // not owned
+  SYCLAllocator* sycl_allocator_;      // not owned
+  SYCLDeviceContext* device_context_;  // not owned
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/sycl/sycl_device.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.h
@@ -149,28 +149,33 @@ class GSYCLInterface {
   }
 
   string GetShortDeviceDescription(int device_id = 0) const {
-    auto _device =
-        GetSYCLAllocator(device_id)->getSyclDevice()->sycl_queue().get_device();
-    auto _name = _device.get_info<cl::sycl::info::device::name>();
-    auto _vendor = _device.get_info<cl::sycl::info::device::vendor>();
-    auto _profile = _device.get_info<cl::sycl::info::device::profile>();
+    Eigen::QueueInterface* queue_ptr = GetQueueInterface(device_id);
+    if (!queue_ptr) {
+      LOG(ERROR)
+          << "Device name cannot be given after Eigen QueueInterface destroyed";
+      return "";
+    }
+    auto device = queue_ptr->sycl_queue().get_device();
+    auto name = device.get_info<cl::sycl::info::device::name>();
+    auto vendor = device.get_info<cl::sycl::info::device::vendor>();
+    auto profile = device.get_info<cl::sycl::info::device::profile>();
 
-    std::string _type;
-    if (_device.is_host()) {
-      _type = "Host";
-    } else if (_device.is_cpu()) {
-      _type = "CPU";
-    } else if (_device.is_gpu()) {
-      _type = "GPU";
-    } else if (_device.is_accelerator()) {
-      _type = "Accelerator";
+    std::string type;
+    if (device.is_host()) {
+      type = "Host";
+    } else if (device.is_cpu()) {
+      type = "CPU";
+    } else if (device.is_gpu()) {
+      type = "GPU";
+    } else if (device.is_accelerator()) {
+      type = "Accelerator";
     } else {
-      _type = "Unknown";
+      type = "Unknown";
     }
 
-    return strings::StrCat("id: ", device_id, " ,type: ", _type, " ,name: ",
-                           _name.c_str(), " ,vendor: ", _vendor.c_str(),
-                           " ,profile: ", _profile.c_str());
+    return strings::StrCat("id: ", device_id, ", type: ", type, ", name: ",
+                           name.c_str(), ", vendor: ", vendor.c_str(),
+                           ", profile: ", profile.c_str());
   }
 };
 

--- a/tensorflow/core/common_runtime/sycl/sycl_device.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.h
@@ -101,14 +101,14 @@ class GSYCLInterface
     }
 
   public:
-    static GSYCLInterface *instance()
+    static const GSYCLInterface *instance()
     {
       // c++11 guarantees that this will be constructed in a thread safe way
       static GSYCLInterface instance;
       return &instance;
     }
 
-    Eigen::QueueInterface * GetQueueInterface(size_t i = 0) {
+    Eigen::QueueInterface * GetQueueInterface(size_t i = 0) const {
       if(!m_queue_interface_.empty()) {
         return m_queue_interface_[i];
       } else {
@@ -117,7 +117,7 @@ class GSYCLInterface
       }
     }
 
-    SYCLAllocator * GetSYCLAllocator(size_t i = 0) {
+    SYCLAllocator * GetSYCLAllocator(size_t i = 0) const {
       if(!m_sycl_allocator_.empty()) {
         return m_sycl_allocator_[i];
       } else {
@@ -126,7 +126,7 @@ class GSYCLInterface
       }
     }
 
-    Allocator * GetCPUAllocator(size_t i = 0) {
+    Allocator * GetCPUAllocator(size_t i = 0) const {
       if(!m_cpu_allocator_.empty()) {
         return m_cpu_allocator_[i];
       } else {
@@ -135,7 +135,7 @@ class GSYCLInterface
       }
     }
 
-    SYCLDeviceContext * GetSYCLContext(size_t i = 0) {
+    SYCLDeviceContext * GetSYCLContext(size_t i = 0) const {
       if(!m_sycl_context_.empty()) {
         return m_sycl_context_[i];
       } else {
@@ -144,7 +144,7 @@ class GSYCLInterface
       }
     }
 
-    string GetShortDeviceDescription(int device_id = 0) {
+    string GetShortDeviceDescription(int device_id = 0) const {
       auto _device = GetSYCLAllocator(device_id)
                          ->getSyclDevice()
                          ->sycl_queue()

--- a/tensorflow/core/common_runtime/sycl/sycl_device.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.h
@@ -27,169 +27,163 @@ limitations under the License.
 
 namespace tensorflow {
 
+class GSYCLInterface {
+  std::vector<Eigen::QueueInterface*> m_queue_interface_;  // owned
+  std::vector<Allocator*> m_cpu_allocator_;                // not owned
+  std::vector<SYCLAllocator*> m_sycl_allocator_;           // owned
+  std::vector<SYCLDeviceContext*> m_sycl_context_;         // owned
 
-class GSYCLInterface
-{
-    std::vector<Eigen::QueueInterface*>     m_queue_interface_;    // owned
-    std::vector<Allocator*>                 m_cpu_allocator_;      // not owned
-    std::vector<SYCLAllocator*>             m_sycl_allocator_;     // owned
-    std::vector<SYCLDeviceContext*>         m_sycl_context_;       // owned
-
-    GSYCLInterface() {
-      bool found_device =false;
-      auto device_list = Eigen::get_sycl_supported_devices();
-      // Obtain list of supported devices from Eigen
-      for (const auto& device : device_list) {
-        if(device.is_gpu()) {
-          // returns first found GPU
-          AddDevice(device);
-          found_device = true;
-        }
-      }
-
-      if(!found_device) {
-        // Currently Intel GPU is not supported
-        LOG(WARNING) << "No OpenCL GPU found that is supported by ComputeCpp, trying OpenCL CPU";
-      }
-
-      for (const auto& device : device_list) {
-        if(device.is_cpu()) {
-          // returns first found CPU
-          AddDevice(device);
-          found_device = true;
-        }
-      }
-
-      if(!found_device) {
-        // Currently Intel GPU is not supported
-        LOG(FATAL) << "No OpenCL GPU nor CPU found that is supported by ComputeCpp";
-      } else {
-        LOG(INFO) << "Found following OpenCL devices:";
-        for (int i = 0; i < device_list.size(); i++) {
-          LOG(INFO) << GetShortDeviceDescription(i);
-        }
+  GSYCLInterface() {
+    bool found_device = false;
+    auto device_list = Eigen::get_sycl_supported_devices();
+    // Obtain list of supported devices from Eigen
+    for (const auto& device : device_list) {
+      if (device.is_gpu()) {
+        // returns first found GPU
+        AddDevice(device);
+        found_device = true;
       }
     }
 
-    ~GSYCLInterface() {
-        m_cpu_allocator_.clear();
-
-        for (auto p : m_sycl_allocator_) {
-          p->Synchronize();
-          p->ClearSYCLDevice();
-          // Cannot delete the Allocator instances, as the Allocator lifetime
-          // needs to exceed any Tensor created by it. There is no way of
-          // knowing when all Tensors have been deallocated, as they are
-          // RefCounted and wait until all instances of a Tensor have been
-          // destroyed before calling Allocator.Deallocate. This could happen at
-          // program exit, which can set up a race condition between destroying
-          // Tensors and Allocators when the program is cleaning up.
-        }
-        m_sycl_allocator_.clear();
-
-        for(auto p : m_sycl_context_) {
-          p->Unref();
-        }
-        m_sycl_context_.clear();
-
-        for (auto p : m_queue_interface_) {
-          p->deallocate_all();
-          delete p;
-          p = nullptr;
-        }
-        m_queue_interface_.clear();
+    if (!found_device) {
+      // Currently Intel GPU is not supported
+      LOG(WARNING) << "No OpenCL GPU found that is supported by ComputeCpp, "
+                      "trying OpenCL CPU";
     }
 
-    void AddDevice(const cl::sycl::device & d) {
-      m_queue_interface_.push_back(new Eigen::QueueInterface(d));
-      m_cpu_allocator_.push_back(cpu_allocator());
-      m_sycl_allocator_.push_back(new SYCLAllocator(m_queue_interface_.back()));
-      m_sycl_context_.push_back(new SYCLDeviceContext());
-    }
-
-  public:
-    static const GSYCLInterface *instance()
-    {
-      // c++11 guarantees that this will be constructed in a thread safe way
-      static GSYCLInterface instance;
-      return &instance;
-    }
-
-    Eigen::QueueInterface * GetQueueInterface(size_t i = 0) const {
-      if(!m_queue_interface_.empty()) {
-        return m_queue_interface_[i];
-      } else {
-        std::cerr << "No cl::sycl::device has been added" << std::endl;
-        return nullptr;
+    for (const auto& device : device_list) {
+      if (device.is_cpu()) {
+        // returns first found CPU
+        AddDevice(device);
+        found_device = true;
       }
     }
 
-    SYCLAllocator * GetSYCLAllocator(size_t i = 0) const {
-      if(!m_sycl_allocator_.empty()) {
-        return m_sycl_allocator_[i];
-      } else {
-        std::cerr << "No cl::sycl::device has been added" << std::endl;
-        return nullptr;
+    if (!found_device) {
+      // Currently Intel GPU is not supported
+      LOG(FATAL)
+          << "No OpenCL GPU nor CPU found that is supported by ComputeCpp";
+    } else {
+      LOG(INFO) << "Found following OpenCL devices:";
+      for (int i = 0; i < device_list.size(); i++) {
+        LOG(INFO) << GetShortDeviceDescription(i);
       }
     }
+  }
 
-    Allocator * GetCPUAllocator(size_t i = 0) const {
-      if(!m_cpu_allocator_.empty()) {
-        return m_cpu_allocator_[i];
-      } else {
-        std::cerr << "No cl::sycl::device has been added" << std::endl;
-        return nullptr;
-      }
+  ~GSYCLInterface() {
+    m_cpu_allocator_.clear();
+
+    for (auto p : m_sycl_allocator_) {
+      p->Synchronize();
+      p->ClearSYCLDevice();
+      // Cannot delete the Allocator instances, as the Allocator lifetime
+      // needs to exceed any Tensor created by it. There is no way of
+      // knowing when all Tensors have been deallocated, as they are
+      // RefCounted and wait until all instances of a Tensor have been
+      // destroyed before calling Allocator.Deallocate. This could happen at
+      // program exit, which can set up a race condition between destroying
+      // Tensors and Allocators when the program is cleaning up.
+    }
+    m_sycl_allocator_.clear();
+
+    for (auto p : m_sycl_context_) {
+      p->Unref();
+    }
+    m_sycl_context_.clear();
+
+    for (auto p : m_queue_interface_) {
+      p->deallocate_all();
+      delete p;
+    }
+    m_queue_interface_.clear();
+  }
+
+  void AddDevice(const cl::sycl::device& d) {
+    m_queue_interface_.push_back(new Eigen::QueueInterface(d));
+    m_cpu_allocator_.push_back(cpu_allocator());
+    m_sycl_allocator_.push_back(new SYCLAllocator(m_queue_interface_.back()));
+    m_sycl_context_.push_back(new SYCLDeviceContext());
+  }
+
+ public:
+  static const GSYCLInterface* instance() {
+    // c++11 guarantees that this will be constructed in a thread safe way
+    static GSYCLInterface instance;
+    return &instance;
+  }
+
+  Eigen::QueueInterface* GetQueueInterface(size_t i = 0) const {
+    if (!m_queue_interface_.empty()) {
+      return m_queue_interface_[i];
+    } else {
+      std::cerr << "No cl::sycl::device has been added" << std::endl;
+      return nullptr;
+    }
+  }
+
+  SYCLAllocator* GetSYCLAllocator(size_t i = 0) const {
+    if (!m_sycl_allocator_.empty()) {
+      return m_sycl_allocator_[i];
+    } else {
+      std::cerr << "No cl::sycl::device has been added" << std::endl;
+      return nullptr;
+    }
+  }
+
+  Allocator* GetCPUAllocator(size_t i = 0) const {
+    if (!m_cpu_allocator_.empty()) {
+      return m_cpu_allocator_[i];
+    } else {
+      std::cerr << "No cl::sycl::device has been added" << std::endl;
+      return nullptr;
+    }
+  }
+
+  SYCLDeviceContext* GetSYCLContext(size_t i = 0) const {
+    if (!m_sycl_context_.empty()) {
+      return m_sycl_context_[i];
+    } else {
+      std::cerr << "No cl::sycl::device has been added" << std::endl;
+      return nullptr;
+    }
+  }
+
+  string GetShortDeviceDescription(int device_id = 0) const {
+    auto _device =
+        GetSYCLAllocator(device_id)->getSyclDevice()->sycl_queue().get_device();
+    auto _name = _device.get_info<cl::sycl::info::device::name>();
+    auto _vendor = _device.get_info<cl::sycl::info::device::vendor>();
+    auto _profile = _device.get_info<cl::sycl::info::device::profile>();
+
+    std::string _type;
+    if (_device.is_host()) {
+      _type = "Host";
+    } else if (_device.is_cpu()) {
+      _type = "CPU";
+    } else if (_device.is_gpu()) {
+      _type = "GPU";
+    } else if (_device.is_accelerator()) {
+      _type = "Accelerator";
+    } else {
+      _type = "Unknown";
     }
 
-    SYCLDeviceContext * GetSYCLContext(size_t i = 0) const {
-      if(!m_sycl_context_.empty()) {
-        return m_sycl_context_[i];
-      } else {
-        std::cerr << "No cl::sycl::device has been added" << std::endl;
-        return nullptr;
-      }
-    }
-
-    string GetShortDeviceDescription(int device_id = 0) const {
-      auto _device = GetSYCLAllocator(device_id)
-                         ->getSyclDevice()
-                         ->sycl_queue()
-                         .get_device();
-      auto _name = _device.get_info<cl::sycl::info::device::name>();
-      auto _vendor = _device.get_info<cl::sycl::info::device::vendor>();
-      auto _profile = _device.get_info<cl::sycl::info::device::profile>();
-
-      std::string _type;
-      if (_device.is_host()) {
-        _type = "Host";
-      } else if (_device.is_cpu()) {
-        _type = "CPU";
-      } else if (_device.is_gpu()) {
-        _type = "GPU";
-      } else if (_device.is_accelerator()) {
-        _type = "Accelerator";
-      } else {
-        _type = "Unknown";
-      }
-
-      return strings::StrCat("id: ", device_id, " ,type: ", _type, " ,name: ",
-                             _name.c_str(), " ,vendor: ", _vendor.c_str(),
-                             " ,profile: ", _profile.c_str());
-    }
+    return strings::StrCat("id: ", device_id, " ,type: ", _type, " ,name: ",
+                           _name.c_str(), " ,vendor: ", _vendor.c_str(),
+                           " ,profile: ", _profile.c_str());
+  }
 };
-
 
 class SYCLDevice : public LocalDevice {
  public:
-  SYCLDevice(const SessionOptions &options, const string &name,
-             Bytes memory_limit, const DeviceLocality &locality,
-             const string &physical_device_desc, SYCLAllocator * sycl_allocator,
-             Allocator *cpu_allocator, SYCLDeviceContext* ctx)
-      : LocalDevice(
-            options,
-            Device::BuildDeviceAttributes(name, DEVICE_SYCL, memory_limit,
-                                          locality, physical_device_desc)),
+  SYCLDevice(const SessionOptions& options, const string& name,
+             Bytes memory_limit, const DeviceLocality& locality,
+             const string& physical_device_desc, SYCLAllocator* sycl_allocator,
+             Allocator* cpu_allocator, SYCLDeviceContext* ctx)
+      : LocalDevice(options, Device::BuildDeviceAttributes(
+                                 name, DEVICE_SYCL, memory_limit, locality,
+                                 physical_device_desc)),
         cpu_allocator_(cpu_allocator),
         sycl_allocator_(sycl_allocator),
         device_context_(ctx) {
@@ -198,21 +192,21 @@ class SYCLDevice : public LocalDevice {
 
   ~SYCLDevice() override;
 
-  void Compute(OpKernel *op_kernel, OpKernelContext *context) override;
-  Allocator *GetAllocator(AllocatorAttributes attr) override;
-  Status MakeTensorFromProto(const TensorProto &tensor_proto,
+  void Compute(OpKernel* op_kernel, OpKernelContext* context) override;
+  Allocator* GetAllocator(AllocatorAttributes attr) override;
+  Status MakeTensorFromProto(const TensorProto& tensor_proto,
                              const AllocatorAttributes alloc_attrs,
-                             Tensor *tensor) override;
+                             Tensor* tensor) override;
 
-  Status FillContextMap(const Graph *graph,
-                        DeviceContextMap *device_context_map) override;
+  Status FillContextMap(const Graph* graph,
+                        DeviceContextMap* device_context_map) override;
 
   Status Sync() override;
 
  private:
-  Allocator         *cpu_allocator_;           // not owned
-  SYCLAllocator     *sycl_allocator_;          // not owned
-  SYCLDeviceContext *device_context_;
+  Allocator* cpu_allocator_;       // not owned
+  SYCLAllocator* sycl_allocator_;  // not owned
+  SYCLDeviceContext* device_context_;
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/sycl/sycl_device.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.h
@@ -108,7 +108,7 @@ class GSYCLInterface {
  public:
   static const GSYCLInterface* instance() {
     // c++11 guarantees that this will be constructed in a thread safe way
-    static GSYCLInterface instance;
+    static const GSYCLInterface instance;
     return &instance;
   }
 


### PR DESCRIPTION
A Tensor's allocator must outlive it, however there is no easy way to determine whether an Allocator has any Tensors still alive, and so we cannot know when it is safe to destroy an allocator. The CPU allocator
gets round this by being deleted, so we adopt this convention here.