### PR TITLE
[OpenCL] Fixes zeroing tensor on wrong device

### DIFF
--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -190,8 +190,9 @@ class BiasGradOp : public OpKernel {
     if (channel == 0) {
       return;  // Nothing to do
     } else if (output_backprop.NumElements() == 0) {
-      // Eigen often crashes by design on empty tensors, but setZero is safe
-      output->template flat<T>().setZero();
+      // Eigen often crashes by design on empty tensors, but this is safe
+      output->template flat<T>().device(context->eigen_device<Device>()) =
+        output->template flat<T>().constant(T(0));
     } else {
       Eigen::DSizes<int, 2> two_dims(batch * height * width, channel);
 #ifdef EIGEN_HAS_INDEX_LIST

--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -240,7 +240,7 @@ void UnsortedSegmentSumFunctor<Device, T, Index>::operator()(
     const TensorShape& segment_ids_shape,
     typename TTypes<Index>::ConstFlat segment_ids, const Index data_size,
     const T* data, typename TTypes<T, 2>::Tensor output) {
-  output.setZero();
+  output.device(d) = output.constant(T(0));
   if (data_size == 0) {
     return;
   }


### PR DESCRIPTION
Eigen's setZero only runs on the CPU which causes a problem if the pointer is actually a device pointer. Instead change it to out.device(d) = out.constant(0), which gives exactly the same result.

Although the comment in the bias_op code suggests that suing anything other than setZero might cause a crash, it doesn't on SYCL or CPU (CUDA uses a different operation to this).