### PR TITLE
[OpenCL] SYCL gather functor needs indices on host

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -517,9 +517,21 @@ TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_GATHER_GPU);
 #endif  // GOOGLE_CUDA
 
 #ifdef TENSORFLOW_USE_SYCL
-#define REGISTER_GATHER_SYCL(type) REGISTER_GATHER_ALL_INDICES(SYCL, type)
+#define REGISTER_GATHER_SYCL(type, index_type)                         \
+  REGISTER_KERNEL_BUILDER(Name("ResourceGather")                       \
+                              .Device(DEVICE_SYCL)                     \
+                              .HostMemory("resource")                  \
+                              .HostMemory("indices")                   \
+                              .TypeConstraint<type>("dtype")           \
+                              .TypeConstraint<index_type>("Tindices"), \
+                          ResourceGatherOp<SYCLDevice, type, index_type>)
 
-TF_CALL_SYCL_NUMBER_TYPES(REGISTER_GATHER_SYCL);
+#define REGISTER_GATHER_SYCL_ALL_INDICES(type) \
+  REGISTER_GATHER_SYCL(type, int32);           \
+  REGISTER_GATHER_SYCL(type, int64)
+
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER_GATHER_SYCL_ALL_INDICES);
+#undef REGISTER_GATHER_SYCL_ALL_INDICES
 #undef REGISTER_GATHER_SYCL
 #endif  // TENSORFLOW_USE_SYCL
 


### PR DESCRIPTION
Changes the registration of the ResourceGatherOp to ensure that the
tensor storing the indices is kept in host memory, as this is required
by the current SYCL implementation of GatherFunctor.