### PR TITLE
[SYCL] Force to link OpenCL with SYCL

### DIFF
--- a/third_party/sycl/sycl/BUILD.tpl
+++ b/third_party/sycl/sycl/BUILD.tpl
@@ -44,6 +44,7 @@ cc_library(
         sycl_library_path("ComputeCpp")
     ],
     includes = ["include/"],
+    linkopts = ["-lOpenCL"],
     linkstatic = 0,
 )
 


### PR DESCRIPTION
I had issues when try to build //tensorflow/tools/pip_package:build_pip_package where OpenCL was not linked.
I remember it's not the first time I had this and there may be a command line option to fix it but I couldn't find it anymore. I tried several things with --linkopt="-lOpenCL" and similar options but it only fixed the issue for some targets...

I think we should always link with libOpenCL.so anyway so it's probably best to add it here?