### PR TITLE
[SYCL] Update to 1.2.1

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -189,10 +189,10 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       name = "eigen_archive",
       urls = [
           #"http://mirror.bazel.build/bitbucket.org/eigen/eigen/get/a61cbe42af5b.tar.gz",
-          "https://bitbucket.org/mehdi_goli/opencl/get/0f66d0b9b580.tar.gz",
+          "https://bitbucket.org/mehdi_goli/opencl/get/8e8bc4c3efee.tar.gz",
       ],
       #sha256 = "ca7beac153d4059c02c8fc59816c82d54ea47fe58365e8aded4082ded0b820c4",
-      strip_prefix = "mehdi_goli-opencl-0f66d0b9b580",
+      strip_prefix = "mehdi_goli-opencl-8e8bc4c3efee",
       build_file = str(Label("//third_party:eigen.BUILD")),
   )
 

--- a/third_party/sycl/crosstool/computecpp.tpl
+++ b/third_party/sycl/crosstool/computecpp.tpl
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import sys
 import tempfile
@@ -9,7 +11,7 @@ CPU_CXX_COMPILER = ('%{host_cxx_compiler}')
 CPU_C_COMPILER = ('%{host_c_compiler}')
 COMPUTECPP_ROOT = ('%{computecpp_root}')
 
-COMPUTECPP_DRIVER= "%s/bin/compute++" % COMPUTECPP_ROOT
+COMPUTECPP_DRIVER = "%s/bin/compute++" % COMPUTECPP_ROOT
 COMPUTECPP_INCLUDE = "%s/include" % COMPUTECPP_ROOT
 
 def get_cpp_info(compiler_flags):
@@ -24,20 +26,6 @@ def get_cpp_info(compiler_flags):
     compiled_file_name = compiler_flags[compiled_file_index]
     compiling_cpp = compiled_file_name.endswith(CPP_extensions)
   return compiling_cpp, compiled_file_name
-
-def get_cpp_info_legacy(compiler_flags):
-  """Check whether the file we are compiling is a CPP file or not."""
-  CPP_extensions = ('.cc', '.c++', '.cpp', '.CPP', '.C', '.cxx')
-  compiling_cpp = False
-  compiled_file_index = None
-  compiled_file_name = None
-
-  if '-c' in compiler_flags:
-    compiled_file_index = compiler_flags.index('-c') + 1
-    compiled_file_name = compiler_flags[compiled_file_index]
-    compiling_cpp = compiled_file_name.endswith(CPP_extensions)
-  return compiling_cpp, compiled_file_index, compiled_file_name
-
 
 def is_external(compiled_file_name, output_file_name):
   """Check if the cfile we are compiling belongs to an external project which
@@ -78,111 +66,19 @@ def get_device_compiler_flags(compiler_flags):
   ]
   return compiler_flags + computecpp_flags
 
-def remove_unknown_computecpp_flags(flags):
-  """Remove flags not recognised by the device compiler. Also remove any CPU
-  specific vectorization flags as they are not applicable to SYCL devices."""
-  unknown_flags = [
-      '-fsanitize',
-      '-fno-canonical-system-headers',
-      '=native',
-      '=core2',
-      'msse',
-      'mavx',
-      'mmmx',
-      'm3dnow',
-      'fma'
-  ]
-  return [flag for flag in flags if not any(x in flag.lower() for x in unknown_flags)]
-
-def get_device_compiler_flags_legacy(compiler_flags):
-  """Remove any flags not used by the device compiler and set up the device
-  compiler flags and includes."""
-  computecpp_flags = [
-      '-sycl-compress-name',
-      '-Wno-unused-variable',
-      '-Wno-c++11-narrowing',
-      '-I', COMPUTECPP_INCLUDE,
-      '-isystem', COMPUTECPP_INCLUDE,
-      '-std=c++11',
-      '-sycl', '-emit-llvm', '-no-serial-memop',
-      '-Xclang', '-cl-denorms-are-zero',
-      '-Xclang', '-cl-fp32-correctly-rounded-divide-sqrt',
-      '-Xclang', '-cl-mad-enable',
-      '-mllvm', '-inline-threshold=10000000',
-  ]
-  return computecpp_flags + remove_unknown_computecpp_flags(compiler_flags)
-
-def add_sycl_env_vars_to_flags_legacy(flags):
-  """Add required env vars to compiler flags as needed for ComputeCpp."""
-  extra_env_vars = [
-      '-DTENSORFLOW_USE_SYCL=1',
-      '-DEIGEN_USE_SYCL=1',
-  ]
-
-  # Silence Clang warning
-  if "clang" in CPU_CXX_COMPILER:
-    extra_env_vars += [
-    '-Wno-unused-const-variable',
-    '-Wno-unused-command-line-argument'
-    ]
-
-  return flags + extra_env_vars
-
-def get_host_compiler_flags_legacy(compiler_flags, bc_out):
-  """Remove device compiler specific flags and set up the host compiler flags."""
-  device_flag_prefixes = ('-MF', '-MD',)
-  host_compiler_flags = [flag for flag in compiler_flags if (not flag.startswith(device_flag_prefixes) and not '.d' in flag)]
-  host_compiler_flags[host_compiler_flags.index('-c')] = "--include"
-  host_compiler_flags = [
-      '-DEIGEN_HAS_C99_MATH',
-      '-xc++',
-      '-Wno-unused-variable',
-      '-I', COMPUTECPP_INCLUDE,
-      '-c', bc_out
-  ] + host_compiler_flags
-  return host_compiler_flags
-
-def isDriverSupported():
+def checkComputeCppIsSupported():
   outputList = check_output([COMPUTECPP_DRIVER, '--version']).split(" ")
   ccpp_version_idx = outputList.index('Device') - 1
+  cpp_version = outputList[ccpp_version_idx];
+  cppVersionList = cpp_version.split(".")
+  if int(cppVersionList[0]) == 0 and int(cppVersionList[1]) < 5:
+    print("Error: ComputeCpp {} is not compatible with the current version of Tensorflow, "
+          "please update to the latest version of ComputeCpp".format(cpp_version), file=sys.stderr)
+    sys.exit(1)
 
-  cppVersionList = outputList[ccpp_version_idx].split(".")
-
-  if((int(cppVersionList[0]) == 0 and int(cppVersionList[1]) >= 5) or int(cppVersionList[0]) > 0):
-    return True
-
-  return False
-
-def useLegacy(output_file_index, output_file_name, compiler_flags):
-  if output_file_index == 1:
-    # we are linking
-    return call([CPU_CXX_COMPILER] + compiler_flags + ['-Wl,--no-undefined'])
-
-  compiling_cpp, compiled_file_index, compiled_file_name = get_cpp_info_legacy(compiler_flags)
-
-  if not compiling_cpp:
-    # compile for C
-    return call([CPU_C_COMPILER] + compiler_flags)
-
-  if is_external(compiled_file_name, output_file_name):
-    return call([CPU_CXX_COMPILER] + compiler_flags)
-
-  compiler_flags = add_sycl_env_vars_to_flags_legacy(compiler_flags)
-
-  filename, file_extension = os.path.splitext(output_file_name)
-  bc_out = filename + '.sycl'
-
-  computecpp_device_compiler_flags = get_device_compiler_flags_legacy(compiler_flags)
-
-  x = call([COMPUTECPP_DRIVER] + computecpp_device_compiler_flags)
-  if x == 0:
-    host_compiler_flags = get_host_compiler_flags_legacy(compiler_flags, bc_out)
-    x = call([CPU_CXX_COMPILER] + host_compiler_flags)
-
-  return x
-
-def useDriver(output_file_index, output_file_name, compiler_flags):
-
+def useDriver(compiler_flags):
+  output_file_index = compiler_flags.index('-o') + 1
+  output_file_name = compiler_flags[output_file_index]
   if output_file_index == 1:
     # we are linking
     return call([CPU_CXX_COMPILER] + compiler_flags)
@@ -219,15 +115,8 @@ def useDriver(output_file_index, output_file_name, compiler_flags):
   return x
 
 def main():
-  compiler_flags = sys.argv[1:]
-
-  output_file_index = compiler_flags.index('-o') + 1
-  output_file_name = compiler_flags[output_file_index]
-
-  if isDriverSupported():
-    return useDriver(output_file_index, output_file_name, compiler_flags)
-
-  return useLegacy(output_file_index, output_file_name, compiler_flags)
+  checkComputeCppIsSupported()
+  return useDriver(sys.argv[1:])
 
 if __name__ == '__main__':
   sys.exit(main())


### PR DESCRIPTION
This is not quite the same commits than we have in codeplaysoftware repository because here we have to remove the legacy support in computecpp.tpl (since we use now use SYCL 1.2.1 we are guaranteed to have the driver).