### PR TITLE
[SYCL] Adds config options to disable double and half support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1060,6 +1060,8 @@ def main():
       set_computecpp_toolkit_path(environ_cp)
     else:
       set_trisycl_include_dir(environ_cp)
+    set_action_env_var(environ_cp, 'TF_USE_DOUBLE_SYCL', 'double types in SYCL', True)
+    set_action_env_var(environ_cp, 'TF_USE_HALF_SYCL', 'half types in SYCL', False)
 
   set_action_env_var(environ_cp, 'TF_NEED_CUDA', 'CUDA', False)
   if (environ_cp.get('TF_NEED_CUDA') == '1' and

--- a/tensorflow/core/framework/register_types.h
+++ b/tensorflow/core/framework/register_types.h
@@ -210,7 +210,7 @@ limitations under the License.
 #define TF_CALL_SYCL_NUMBER_TYPES(m)  TF_CALL_float(m)
 #else  // __ANDROID_TYPES_SLIM__
 #define TF_CALL_SYCL_NUMBER_TYPES(m)    \
-    TF_CALL_half(m)                     \
+    TF_CALL_SYCL_half(m)                \
     TF_CALL_float(m)                    \
     TF_CALL_SYCL_double(m)
 #endif  // __ANDROID_TYPES_SLIM__

--- a/third_party/sycl/crosstool/computecpp.tpl
+++ b/third_party/sycl/crosstool/computecpp.tpl
@@ -10,6 +10,8 @@ from subprocess import call, Popen, PIPE, check_output
 CPU_CXX_COMPILER = ('%{host_cxx_compiler}')
 CPU_C_COMPILER = ('%{host_c_compiler}')
 COMPUTECPP_ROOT = ('%{computecpp_root}')
+DOUBLE_SUPPORT = ('%{double_support}')
+HALF_SUPPORT = ('%{half_support}')
 
 COMPUTECPP_DRIVER = "%s/bin/compute++" % COMPUTECPP_ROOT
 COMPUTECPP_INCLUDE = "%s/include" % COMPUTECPP_ROOT
@@ -79,6 +81,13 @@ def checkComputeCppIsSupported():
 def useDriver(compiler_flags):
   output_file_index = compiler_flags.index('-o') + 1
   output_file_name = compiler_flags[output_file_index]
+
+  # Check whether we should disable double or half support
+  if DOUBLE_SUPPORT == "0":
+    compiler_flags += ['-DTENSORFLOW_SYCL_NO_DOUBLE=1']
+  if HALF_SUPPORT == "0":
+    compiler_flags += ['-DTENSORFLOW_SYCL_NO_HALF=1']
+
   if output_file_index == 1:
     # we are linking
     return call([CPU_CXX_COMPILER] + compiler_flags)

--- a/third_party/sycl/sycl_configure.bzl
+++ b/third_party/sycl/sycl_configure.bzl
@@ -8,6 +8,8 @@
   * TRISYCL_INCLUDE_DIR: The path to the include directory of triSYCL.
                          (if using triSYCL instead of ComputeCPP)
   * PYTHON_LIB_PATH: The path to the python lib
+  * TF_USE_DOUBLE_SYCL: boolean value representing double support
+  * TF_USE_HALF_SYCL: boolean value representing half support
 """
 
 _HOST_CXX_COMPILER = "HOST_CXX_COMPILER"
@@ -15,6 +17,8 @@ _HOST_C_COMPILER= "HOST_C_COMPILER"
 _COMPUTECPP_TOOLKIT_PATH = "COMPUTECPP_TOOLKIT_PATH"
 _TRISYCL_INCLUDE_DIR = "TRISYCL_INCLUDE_DIR"
 _PYTHON_LIB_PATH = "PYTHON_LIB_PATH"
+_DOUBLE_SUPPORT = "TF_USE_DOUBLE_SYCL"
+_HALF_SUPPORT = "TF_USE_HALF_SYCL"
 
 def _enable_sycl(repository_ctx):
   if "TF_NEED_OPENCL_SYCL" in repository_ctx.os.environ:
@@ -24,6 +28,16 @@ def _enable_sycl(repository_ctx):
 
 def _enable_compute_cpp(repository_ctx):
   return _COMPUTECPP_TOOLKIT_PATH in repository_ctx.os.environ
+
+def _enable_double(repository_ctx):
+  if _DOUBLE_SUPPORT in repository_ctx.os.environ:
+    return repository_ctx.os.environ[_DOUBLE_SUPPORT]
+  return "0"
+
+def _enable_half(repository_ctx):
+  if _HALF_SUPPORT in repository_ctx.os.environ:
+    return repository_ctx.os.environ[_HALF_SUPPORT]
+  return "0"
 
 def auto_configure_fail(msg):
   """Output failure message when auto configuration fails."""
@@ -195,6 +209,8 @@ def _sycl_autoconf_imp(repository_ctx):
         "%{host_cxx_compiler}" : find_cc(repository_ctx),
         "%{host_c_compiler}" : find_c(repository_ctx),
         "%{computecpp_root}"  : computecpp_root,
+        "%{double_support}" : _enable_double(repository_ctx),
+        "%{half_support}" : _enable_half(repository_ctx),
       })
 
       _check_dir(repository_ctx, computecpp_root)


### PR DESCRIPTION
Note that currently the half data type is not supported in SYCL Eigen, so trying to enable this may cause compilation errors.
These options can be set at configure time, either with the interactive prompts or by setting the environment variables `TF_USE_DOUBLE_SYCL` and `TF_USE_HALF_SYCL`.