### PR TITLE
[SYCL] Bazel header dependency hotfix

### DIFF
--- a/third_party/sycl/crosstool/computecpp.tpl
+++ b/third_party/sycl/crosstool/computecpp.tpl
@@ -102,6 +102,13 @@ def useDriver(compiler_flags):
     return call([CPU_C_COMPILER] + compiler_flags)
 
   if is_external(compiled_file_name, output_file_name):
+    if('g++' == CPU_CXX_COMPILER or '/g++' in CPU_CXX_COMPILER):
+      # If compiling with gcc, need to add the flag to force the compiler to
+      # report included dependencies according to the directory specified by
+      # the include flags. By default gcc will use either a relative or
+      # absolute path depending on which is shortest, and that confuses bazel's
+      # header dependency checking.
+      compiler_flags += ['-fno-canonical-system-headers']
     return call([CPU_CXX_COMPILER] + compiler_flags)
 
   filename, file_extension = os.path.splitext(output_file_name)


### PR DESCRIPTION
Add the canonical header flag to gcc when compiling non-SYCL C++. This
flag is required to ensure that gcc will report the dependencies using
the directories provided by bazel, whereas by default gcc will use
a relative or absolute path depending on which is shortest. In general
this does not cause a problem, as the bazel cache has a fairly long
name and so the relative path is almost always shorter than the absolute
path, however this might not be the case when you change the location of
the bazel cache.

Regession introduced: bfaac96
Fixes: #215
See also: https://github.com/bazelbuild/bazel/issues/1642