### PR TITLE
WIP: [SYCL] Add SYCL bitcode configure option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -837,6 +837,22 @@ def set_computecpp_toolkit_path(environ_cp):
   write_action_env_to_bazelrc('COMPUTECPP_TOOLKIT_PATH',
                               computecpp_toolkit_path)
 
+
+def set_computecpp_bitcode_target(environ_cp):
+  """Set the SYCL target bitcode to compile IR for."""
+  default_target = 'spir64'
+  ask_sycl_target = ('Please specify which bitcode to target when compiling '
+                     'SYCL code. [Default is %s]: ') % (default_target)
+
+  # TODO(jwlawson): Add check to ensure that the specified target is valid
+  sycl_target = get_from_env_or_user_or_default(
+      environ_cp, 'TF_SYCL_BITCODE_TARGET', ask_sycl_target,
+      default_target)
+
+  environ_cp['TF_SYCL_BITCODE_TARGET'] = sycl_target
+  write_action_env_to_bazelrc('TF_SYCL_BITCODE_TARGET', sycl_target)
+
+
 def set_trisycl_include_dir(environ_cp):
   """Set TRISYCL_INCLUDE_DIR"""
   ask_trisycl_include_dir = ('Please specify the location of the triSYCL '
@@ -1024,6 +1040,7 @@ def main():
     set_action_env_var(environ_cp, 'TF_NEED_COMPUTECPP', 'ComputeCPP', True)
     if environ_cp.get('TF_NEED_COMPUTECPP') == '1':
       set_computecpp_toolkit_path(environ_cp)
+      set_computecpp_bitcode_target(environ_cp)
     else:
       set_trisycl_include_dir(environ_cp)
     set_sycl_data_types(environ_cp)

--- a/third_party/sycl/sycl_configure.bzl
+++ b/third_party/sycl/sycl_configure.bzl
@@ -192,7 +192,7 @@ def _sycl_autoconf_impl(repository_ctx):
     gcc_toolchain_path = ""
     gcc_toolchain_name = ""
     opencl_includes = ""
-  spir_type = repository_ctx.os.environ["BITCODE_TARGET"]
+  spir_type = repository_ctx.os.environ["TF_SYCL_BITCODE_TARGET"]
 
   # SYCL toolchain bits
   if not _enable_sycl(repository_ctx):


### PR DESCRIPTION
Add a configure time option to specify the SYCL target bitcode to pass
to ComputeCpp. By default this is spir64 for AMD devices, but it can be
changed to match the actual device to compiler for.

Note: There is no check to ensure that the target is supported by
ComputeCpp, nor is there a check to ensure that the traget matches the
device.