### PR TITLE
Register missing ops

### DIFF
--- a/tensorflow/core/kernels/betainc_op.cc
+++ b/tensorflow/core/kernels/betainc_op.cc
@@ -33,6 +33,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class BetaincOp : public OpKernel {
@@ -165,5 +168,15 @@ REGISTER_GPU_KERNELS(double);
 #undef REGISTER_GPU_KERNELS
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(type)                                  \
+  REGISTER_KERNEL_BUILDER(                                           \
+      Name("Betainc").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      BetaincOp<SYCLDevice, type>);
+
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/bucketize_op.h
+++ b/tensorflow/core/kernels/bucketize_op.h
@@ -32,7 +32,16 @@ struct BucketizeFunctor {
   static Status Compute(OpKernelContext* context,
                         const typename TTypes<T, 1>::ConstTensor& input,
                         const std::vector<float>& boundaries_vector,
-                        typename TTypes<int32, 1>::Tensor& output);
+                        typename TTypes<int32, 1>::Tensor& output) {
+    const int N = input.size();
+    for (int i = 0; i < N; i++) {
+      auto first_bigger_it = std::upper_bound(
+          boundaries_vector.begin(), boundaries_vector.end(), input(i));
+      output(i) = first_bigger_it - boundaries_vector.begin();
+    }
+
+    return Status::OK();
+	}
 };
 
 }  // namespace functor

--- a/tensorflow/core/kernels/cross_op.cc
+++ b/tensorflow/core/kernels/cross_op.cc
@@ -35,6 +35,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename Type>
 class CrossOp : public OpKernel {
@@ -109,5 +112,14 @@ TF_CALL_REAL_NUMBER_TYPES(DECLARE_GPU_KERNEL);
 TF_CALL_REAL_NUMBER_TYPES(REGISTER_GPU_KERNEL);
 #undef REGISTER_GPU_KERNEL
 #endif
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNEL(type)                                 \
+  REGISTER_KERNEL_BUILDER(                                         \
+      Name("Cross").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      CrossOp<SYCLDevice, type>);
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER_SYCL_KERNEL);
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/data_format_ops.cc
+++ b/tensorflow/core/kernels/data_format_ops.cc
@@ -27,6 +27,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class DataFormatDimMapOp : public OpKernel {
@@ -172,5 +175,23 @@ TF_CALL_int32(REGISTER_GPU_KERNEL);
 TF_CALL_int64(REGISTER_GPU_KERNEL);
 #undef REGISTER_GPU_KERNEL
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNEL(T)                                            \
+  REGISTER_KERNEL_BUILDER(                                                 \
+      Name("DataFormatDimMap").Device(DEVICE_SYCL).TypeConstraint<T>("T"), \
+      DataFormatDimMapOp<SYCLDevice, T>);
+TF_CALL_int32(REGISTER_SYCL_KERNEL);
+TF_CALL_int64(REGISTER_SYCL_KERNEL);
+#undef REGISTER_SYCL_KERNEL
+
+#define REGISTER_SYCL_KERNEL(T)                                                \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("DataFormatVecPermute").Device(DEVICE_SYCL).TypeConstraint<T>("T"), \
+      DataFormatVecPermuteOp<SYCLDevice, T>);
+TF_CALL_int32(REGISTER_SYCL_KERNEL);
+TF_CALL_int64(REGISTER_SYCL_KERNEL);
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/extract_image_patches_op.cc
+++ b/tensorflow/core/kernels/extract_image_patches_op.cc
@@ -35,6 +35,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 static inline void ParseAttributeVec4(OpKernelConstruction* context,
                                       const string& attr_name,
@@ -161,5 +164,16 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER);
 #undef REGISTER
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER(T)                                                           \
+  REGISTER_KERNEL_BUILDER(                                                    \
+      Name("ExtractImagePatches").Device(DEVICE_SYCL).TypeConstraint<T>("T"), \
+      ExtractImagePatchesOp<SYCLDevice, T>);
+
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER);
+
+#undef REGISTER
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/fake_quant_ops.cc
+++ b/tensorflow/core/kernels/fake_quant_ops.cc
@@ -31,6 +31,9 @@ using tensorflow::DEVICE_CPU;
 #if GOOGLE_CUDA
 using tensorflow::DEVICE_GPU;
 #endif
+#ifdef TENSORFLOW_USE_SYCL
+using tensorflow::DEVICE_SYCL;
+#endif  // TENSORFLOW_USE_SYCL
 using tensorflow::OpKernel;
 using tensorflow::OpKernelConstruction;
 using tensorflow::OpKernelContext;
@@ -43,6 +46,9 @@ using tensorflow::errors::InvalidArgument;
 namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 namespace {
 bool IsNumBitsValid(int num_bits) { return num_bits >= 2 && num_bits <= 16; }
@@ -166,6 +172,14 @@ REGISTER_KERNEL_BUILDER(
     Name("FakeQuantWithMinMaxArgsGradient").Device(DEVICE_GPU),
     FakeQuantWithMinMaxArgsGradientOp<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxArgs").Device(DEVICE_SYCL),
+                        FakeQuantWithMinMaxArgsOp<SYCLDevice>);
+REGISTER_KERNEL_BUILDER(
+    Name("FakeQuantWithMinMaxArgsGradient").Device(DEVICE_SYCL),
+    FakeQuantWithMinMaxArgsGradientOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 // -----------------------------------------------------------------------------
 // Implementation of FakeQuantWithMinMaxVarsOp, see its documentation in
@@ -295,6 +309,14 @@ REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsGradient")
                             .HostMemory("max"),
                         FakeQuantWithMinMaxVarsGradientOp<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVars").Device(DEVICE_SYCL),
+                        FakeQuantWithMinMaxVarsOp<SYCLDevice>);
+REGISTER_KERNEL_BUILDER(
+    Name("FakeQuantWithMinMaxVarsGradient").Device(DEVICE_SYCL),
+    FakeQuantWithMinMaxVarsGradientOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 // -----------------------------------------------------------------------------
 // Implementation of FakeQuantWithMinMaxVarsPerChannelOp, see its documentation
@@ -444,5 +466,14 @@ REGISTER_KERNEL_BUILDER(Name("FakeQuantWithMinMaxVarsPerChannelGradient")
                             .HostMemory("max"),
                         FakeQuantWithMinMaxVarsPerChannelGradientOp<GPUDevice>);
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("FakeQuantWithMinMaxVarsPerChannel").Device(DEVICE_SYCL),
+    FakeQuantWithMinMaxVarsPerChannelOp<SYCLDevice>);
+REGISTER_KERNEL_BUILDER(
+    Name("FakeQuantWithMinMaxVarsPerChannelGradient").Device(DEVICE_SYCL),
+    FakeQuantWithMinMaxVarsPerChannelGradientOp<SYCLDevice>);
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/functional_ops.cc
+++ b/tensorflow/core/kernels/functional_ops.cc
@@ -29,6 +29,9 @@ typedef Eigen::GpuDevice GPUDevice;
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef FunctionLibraryRuntime::Handle FHandle;
 typedef std::vector<Tensor> TensorVec;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 namespace {
 
@@ -182,6 +185,10 @@ class FunctionalIf : public AsyncOpKernel {
 REGISTER_KERNEL_BUILDER(Name("_If").Device(DEVICE_CPU), FunctionalIf);
 REGISTER_KERNEL_BUILDER(Name("_If").Device(DEVICE_GPU).HostMemory("cond"),
                         FunctionalIf);
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("_If").Device(DEVICE_SYCL).HostMemory("cond"),
+                        FunctionalIf);
+#endif  // TENSORFLOW_USE_SYCL
 
 class FunctionalWhile : public AsyncOpKernel {
  public:
@@ -318,5 +325,8 @@ class FunctionalWhile : public AsyncOpKernel {
 };
 REGISTER_KERNEL_BUILDER(Name("_While").Device(DEVICE_CPU), FunctionalWhile);
 REGISTER_KERNEL_BUILDER(Name("_While").Device(DEVICE_GPU), FunctionalWhile);
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(Name("_While").Device(DEVICE_SYCL), FunctionalWhile);
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/reduction_ops_all.cc
+++ b/tensorflow/core/kernels/reduction_ops_all.cc
@@ -45,4 +45,19 @@ REGISTER_KERNEL_BUILDER(
     ReductionOp<GPUDevice, bool, int64, Eigen::internal::AndReducer>);
 #endif
 
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("All")
+        .TypeConstraint<int32>("Tidx")
+        .Device(DEVICE_SYCL)
+        .HostMemory("reduction_indices"),
+    ReductionOp<SYCLDevice, bool, int32, Eigen::internal::AndReducer>);
+REGISTER_KERNEL_BUILDER(
+    Name("All")
+        .TypeConstraint<int64>("Tidx")
+        .Device(DEVICE_SYCL)
+        .HostMemory("reduction_indices"),
+    ReductionOp<SYCLDevice, bool, int64, Eigen::internal::AndReducer>);
+#endif  // TENSORFLOW_USE_SYCL
+
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/reduction_ops_any.cc
+++ b/tensorflow/core/kernels/reduction_ops_any.cc
@@ -45,4 +45,19 @@ REGISTER_KERNEL_BUILDER(
     ReductionOp<GPUDevice, bool, int64, Eigen::internal::OrReducer>);
 #endif
 
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("Any")
+        .TypeConstraint<int32>("Tidx")
+        .Device(DEVICE_SYCL)
+        .HostMemory("reduction_indices"),
+    ReductionOp<SYCLDevice, bool, int32, Eigen::internal::OrReducer>);
+REGISTER_KERNEL_BUILDER(
+    Name("Any")
+        .TypeConstraint<int64>("Tidx")
+        .Device(DEVICE_SYCL)
+        .HostMemory("reduction_indices"),
+    ReductionOp<SYCLDevice, bool, int64, Eigen::internal::OrReducer>);
+#endif  // TENSORFLOW_USE_SYCL
+
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/softplus_op.cc
+++ b/tensorflow/core/kernels/softplus_op.cc
@@ -30,6 +30,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class SoftplusOp : public UnaryElementWiseOp<T, SoftplusOp<Device, T>> {
@@ -125,5 +128,18 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(type)                                       \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("Softplus").Device(DEVICE_SYCL).TypeConstraint<type>("T"),     \
+      SoftplusOp<SYCLDevice, type>);                                      \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("SoftplusGrad").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      SoftplusGradOp<SYCLDevice, type>);
+
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/softsign_op.cc
+++ b/tensorflow/core/kernels/softsign_op.cc
@@ -30,6 +30,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 template <typename Device, typename T>
 class SoftsignOp : public UnaryElementWiseOp<T, SoftsignOp<Device, T>> {
@@ -126,5 +129,18 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
 
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER_SYCL_KERNELS(type)                                       \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("Softsign").Device(DEVICE_SYCL).TypeConstraint<type>("T"),     \
+      SoftsignOp<SYCLDevice, type>);                                      \
+  REGISTER_KERNEL_BUILDER(                                                \
+      Name("SoftsignGrad").Device(DEVICE_SYCL).TypeConstraint<type>("T"), \
+      SoftsignGradOp<SYCLDevice, type>);
+
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER_SYCL_KERNELS);
+#undef REGISTER_SYCL_KERNELS
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/spacetobatch_op.cc
+++ b/tensorflow/core/kernels/spacetobatch_op.cc
@@ -38,6 +38,9 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 namespace {
 
@@ -282,5 +285,23 @@ TF_CALL_REAL_NUMBER_TYPES(REGISTER);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER);
 #undef REGISTER
 #endif  // GOOGLE_CUDA
+
+#ifdef TENSORFLOW_USE_SYCL
+#define REGISTER(T)                                         \
+  REGISTER_KERNEL_BUILDER(Name("SpaceToBatchND")            \
+                              .Device(DEVICE_SYCL)          \
+                              .TypeConstraint<T>("T")       \
+                              .HostMemory("block_shape")    \
+                              .HostMemory("paddings"),      \
+                          SpaceToBatchNDOp<SYCLDevice, T>); \
+  REGISTER_KERNEL_BUILDER(Name("SpaceToBatch")              \
+                              .Device(DEVICE_SYCL)          \
+                              .TypeConstraint<T>("T")       \
+                              .HostMemory("paddings"),      \
+                          SpaceToBatchOp<SYCLDevice, T>);
+
+TF_CALL_SYCL_NUMBER_TYPES(REGISTER);
+#undef REGISTER
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // end namespace tensorflow

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -132,10 +132,10 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       name = "eigen_archive",
       urls = [
           "http://mirror.bazel.build/bitbucket.org/mehdi_goli/opencl/get/d241b80712dc.tar.gz",
-          "https://bitbucket.org/mehdi_goli/opencl/get/d260fad567a6.tar.gz",
+          "https://bitbucket.org/mehdi_goli/opencl/get/59153ca2f359.tar.gz",
       ],
-      sha256 = "671298ce347e933f3717d6f51c38af1579c4b4c507798ac1eaa7179ed62709b9",
-      strip_prefix = "mehdi_goli-opencl-d260fad567a6",
+      sha256 = "914e87393caa2b3afc6779d4618d266c164ff26c6a6c1ad555789d0280bf17e8",
+      strip_prefix = "mehdi_goli-opencl-59153ca2f359",
       build_file = str(Label("//third_party:eigen.BUILD")),
   )
 


### PR DESCRIPTION
Missing operations for which SYCL can use the same code as the CPU version.
BucketizeOp is separated because some code had to moved from .cc to .h file.
Eigen version bump was needed for betainc op.